### PR TITLE
Add five isolated browser profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all help deps subsystems install typecheck test test-bun test-browser test-python test-cyberful-os test-network test-zap test-codex test-all build run docs docs-build clean
+.PHONY: all help deps subsystems install typecheck test test-bun test-browser test-python test-cyberful-os test-network test-zap test-codex test-all build run browser-run-1 browser-run-2 browser-run-3 browser-run-4 browser-run-5 docs docs-build clean
 
 PYTHON ?= python3
 
@@ -21,6 +21,7 @@ help:
 	@echo "  make build        Build standalone binaries for all platforms (gated on test-codex)"
 	@echo "  make install      Build and install the 'cyberful' command for this system"
 	@echo "  make run          Launch Cyberful from the repository root"
+	@echo "  make browser-run-{1..5} Open a persistent browser profile for target pre-authentication"
 	@echo "  make docs         Serve the engineer docs locally"
 	@echo "  make docs-build   Build the static documentation site"
 	@echo "  make clean        Remove generated build and documentation output"
@@ -96,6 +97,9 @@ install:
 # the app layers `.env` itself, so no --env-file is needed.
 run:
 	cd $(dir $(abspath $(firstword $(MAKEFILE_LIST)))) && CYBERFUL_BUILD_ID="$${CYBERFUL_BUILD_ID:-$$(bun ./cyberful/script/source-build-id.ts)}" bun --preload ./cyberful/node_modules/@opentui/solid/scripts/preload.ts --conditions=browser cyberful/src/index.ts $(ARGS)
+
+browser-run-1 browser-run-2 browser-run-3 browser-run-4 browser-run-5:
+	bun cyberful/script/browser-run.ts $(@:browser-run-%=%)
 
 docs:
 	cd $(dir $(abspath $(firstword $(MAKEFILE_LIST)))) && ./scripts/serve-docs.sh

--- a/README.md
+++ b/README.md
@@ -428,8 +428,10 @@ wedged worker cannot leave Cyberful-owned processes or Docker workloads active.
 ### First launch: the browser
 
 The browser MCP drives open-source **Chromium** (patchright's Chrome-for-Testing)
-by default — no proprietary Chrome, and a dedicated `cyberful` profile under
-`~/.cyberful/browser`. The driver ships inside the binary; only Chromium itself
+by default — no proprietary Chrome, and up to five dedicated profiles under
+`~/.cyberful/browser`. Every `browser_*` tool accepts `profile: 1..5` (profile 1
+is the default), so separate authorized accounts keep independent cookies,
+storage, tabs, and downloads. The driver ships inside the binary; only Chromium itself
 (~150 MB) is fetched on first launch by a visible preflight, streaming the
 download, then reused. Target cookies persist in that isolated profile by default,
 while browser-owned background calls are disabled for both Chromium and Chrome so a
@@ -438,7 +440,10 @@ Google Chrome instead (skips login OTP, passes Cloudflare), set
 `CYBER_BROWSER_CHANNEL=chrome` in the `.env` of the directory you launch from; it
 uses the default Cyberful profile unless `CYBER_BROWSER_USER_DATA_DIR=<profile>` is
 also set. Fully close the manually seeded browser before Cyberful starts so the
-profile lock is released. Disable the preflight with
+profile lock is released. From a source checkout, run `make browser-run-1`
+through `make browser-run-5` to open and pre-authenticate each identity, close
+each browser, then describe the account-to-profile mapping in the Cyberful prompt.
+Disable the preflight with
 `CYBERFUL_SKIP_BROWSER_PREFLIGHT=1`. See **[Browser MCP](docs/runtimes/browser.md)** for the full reference:
 choosing Chromium vs real Chrome, and how to open a dedicated Chrome and log into a target once so an
 authorized bug-bounty / pentest engagement reuses that authenticated session.

--- a/cyberful/builtin/agents/pentest/recon.md
+++ b/cyberful/builtin/agents/pentest/recon.md
@@ -46,6 +46,9 @@ You **enumerate and flag - you do NOT exploit.**
   on captured traffic -- wait for `zap_get_passive_scan_status`, inspect `zap://alerts`, and record its
   findings as **SUSPECTED** leads. Read-only in
   recon: you map and flag, never run an active scan or send a payload (that is the exploit phase).
+- When the mission identifies different accounts in browser profiles 1-5, pass that exact `profile` to every
+  `browser_*` call and preserve the profile/account mapping in `RECON.md`. Compare ordinary journeys across
+  identities without copying cookies, tokens, local storage, or other session material between profiles.
 
 ## Production traffic discipline - one shared egress budget
 

--- a/cyberful/builtin/skills/ZAP.md
+++ b/cyberful/builtin/skills/ZAP.md
@@ -37,7 +37,8 @@ current phase authorize that exact action.
 
 ## Readiness and automatic capture
 
-Before the first target request, call `browser_status`. The proxy path is attested only when
+Before the first target request from each browser identity you will use, call `browser_status` with that
+profile number. The proxy path is attested only when
 `proxy.configured` is `true` and `proxy.mode` is exactly `zap`. A `pending` result is not permission to
 navigate: recheck at a bounded interval, then record a platform blocker if it does not settle. A
 `direct-fallback` result is explicit degraded operation; follow the mission's fallback policy and never
@@ -54,7 +55,8 @@ searches, preserve message IDs in handoffs, and leave final report generation to
 
 ## Normal workflow
 
-1. Attest `browser_status`, then use `browser_*` for the real application flow.
+1. Attest `browser_status` for each selected profile, then consistently pass the same `profile` to
+   `browser_*` for that account's real application flow.
 2. Search a bounded metadata page with `zap_history_search`; use `zap_history_get` to inspect selected
    metadata, and set `include_bodies: true` only for the smallest pair whose content is actually needed.
 3. Replay the raw request with `zap_http_request`, changing one factor at a time and comparing the

--- a/cyberful/script/browser-run.ts
+++ b/cyberful/script/browser-run.ts
@@ -1,0 +1,46 @@
+// ── Manual Browser Profile Launcher ─────────────────────────────────
+// Opens one of Cyberful's five persistent browser identities so a human can
+// establish an authorized target session before starting the application.
+// → cyberful/src/dependency/browser-profile.ts — resolves stable profile paths.
+// → mcps/browser/browser_mcp.mjs — owns the headed Chromium process and profile lock.
+// @docs/runtimes/browser.md
+// ─────────────────────────────────────────────────────────────────────
+
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { BrowserProfile } from "../src/dependency/browser-profile"
+
+const profileArgument = process.argv[2]
+const profile = Number(profileArgument)
+if (!BrowserProfile.isBrowserProfileId(profile)) {
+  process.stderr.write("Usage: bun cyberful/script/browser-run.ts <profile 1-5>\n")
+  process.exit(2)
+}
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..")
+const launcher = path.join(repositoryRoot, "mcps", "browser", "bin", "cyber-browser")
+const profileDirectory = BrowserProfile.browserProfileDir(profile)
+
+process.stderr.write(`Opening Cyberful browser profile ${profile}: ${profileDirectory}\n`)
+process.stderr.write("Sign in to the authorized target, then close the browser before starting Cyberful.\n")
+
+const child = Bun.spawn([launcher], {
+  env: BrowserProfile.manualBrowserProfileEnv(profile),
+  stdin: "inherit",
+  stdout: "inherit",
+  stderr: "inherit",
+})
+
+// ── The Manual Launcher Owns Browser Shutdown ───────────────────────
+// Eager browser mode intentionally waits forever while the Chromium window is
+// open. Terminal interruption must therefore reach the child, which performs
+// bounded context cleanup and releases the persistent profile lock. Closing the
+// browser normally exits the child and requires no second cleanup attempt. The
+// parent waits for that exit so a completed Make target proves the profile is
+// available to the next Cyberful phase gateway.
+// ─────────────────────────────────────────────────────────────────────
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.once(signal, () => child.kill(signal))
+}
+
+process.exitCode = await child.exited

--- a/cyberful/src/bootstrap-browser.ts
+++ b/cyberful/src/bootstrap-browser.ts
@@ -1,14 +1,14 @@
 // ── Embedded Browser Bootstrap ───────────────────────────────────
 // Materializes the browser MCP and its binary assets from release definitions,
-// then points installed builds at the resulting per-build cache layout.
+// then binds source and installed builds to five stable profile identities.
 // → cyberful/src/dependency/browser-preflight.ts — acquires Chromium separately on first use.
 // → mcps/browser/bin/cyber-browser — consumes the materialized driver layout.
 // @docs/runtimes/browser.md
 // ─────────────────────────────────────────────────────────────────
 import fs from "node:fs"
-import os from "node:os"
 import path from "node:path"
 import { Global } from "@/global"
+import { browserHome, browserProfileDir } from "@/dependency/browser-profile"
 
 declare const CYBERFUL_EMBEDDED_BROWSER: Record<string, string> | undefined
 declare const CYBERFUL_EMBEDDED_BROWSER_BIN: Record<string, string> | undefined
@@ -21,15 +21,11 @@ function buildIdSlug(): string {
 
 // ── Browser State Outlives A Release Cache ───────────────────────
 // Driver files are immutable build assets and belong in a build-specific cache,
-// but Chromium and the isolated profile are large mutable user state. Keeping
+// but Chromium and the isolated profiles are large mutable user state. Keeping
 // those resources in a stable browser home avoids downloading Chromium after
-// every upgrade and preserves the dedicated Cyberful profile. Explicit command
+// every upgrade and preserves the dedicated Cyberful profiles. Explicit command
 // and path overrides still win, so source runs and operator policy remain intact.
 // ─────────────────────────────────────────────────────────────────
-export function browserHome(): string {
-  return path.join(os.homedir(), ".cyberful", "browser")
-}
-
 function materializeBrowser(): boolean {
   const text = typeof CYBERFUL_EMBEDDED_BROWSER === "undefined" ? undefined : CYBERFUL_EMBEDDED_BROWSER
   const bin = typeof CYBERFUL_EMBEDDED_BROWSER_BIN === "undefined" ? undefined : CYBERFUL_EMBEDDED_BROWSER_BIN
@@ -62,15 +58,25 @@ function materializeBrowser(): boolean {
   }
 
   process.env.CYBER_BROWSER_MCP_COMMAND = path.join(root, "browser", "bin", "cyber-browser")
-  // Chromium download + the cyberful profile live in the stable home, not the per-build cache.
-  const home = browserHome()
-  if (!process.env.CYBER_BROWSER_BROWSERS_PATH) process.env.CYBER_BROWSER_BROWSERS_PATH = path.join(home, ".browsers")
-  if (!process.env.CYBER_BROWSER_USER_DATA_DIR) {
-    process.env.CYBER_BROWSER_USER_DATA_DIR = path.join(home, "profiles", "cyberful")
-  }
   return true
 }
 
+// ── Source And Release Launches Share Browser State ─────────────────
+// The embedded payload exists only in release binaries, but manual profile
+// seeding is a source-tree command. Both launch paths must resolve the same
+// Chromium cache and first persistent identity or a successful pre-login would
+// disappear when Cyberful starts. Environment overrides remain authoritative,
+// including the numbered profile-one override used by the five-profile router.
+// @docs/runtimes/browser.md
+// ─────────────────────────────────────────────────────────────────────
+const home = browserHome()
+if (!process.env.CYBER_BROWSER_BROWSERS_PATH) process.env.CYBER_BROWSER_BROWSERS_PATH = path.join(home, ".browsers")
+if (!process.env.CYBER_BROWSER_USER_DATA_DIR && !process.env.CYBER_BROWSER_USER_DATA_DIR_1) {
+  process.env.CYBER_BROWSER_USER_DATA_DIR = browserProfileDir(1)
+}
+
 export const bootstrapBrowserReady = materializeBrowser()
+
+export { browserHome }
 
 export * as BootstrapBrowser from "./bootstrap-browser"

--- a/cyberful/src/dependency/browser-profile.test.ts
+++ b/cyberful/src/dependency/browser-profile.test.ts
@@ -1,0 +1,72 @@
+// ── Browser Profile Identity Tests ──────────────────────────────────
+// Protects stable multi-profile paths and legacy profile-one override behavior
+// used by both manual pre-authentication and autonomous browser routing.
+// → cyberful/src/dependency/browser-profile.ts — resolves the tested identities.
+// @docs/runtimes/browser.md
+// ─────────────────────────────────────────────────────────────────────
+
+import { describe, expect, test } from "bun:test"
+import { BrowserProfile } from "./browser-profile"
+
+describe("browser profile identity", () => {
+  test("assigns five distinct stable profile and artifact directories", () => {
+    const env = {}
+    const profiles = BrowserProfile.BROWSER_PROFILE_IDS.map((profile) =>
+      BrowserProfile.browserProfileDir(profile, env, "/home/tester"),
+    )
+    const artifacts = BrowserProfile.BROWSER_PROFILE_IDS.map((profile) =>
+      BrowserProfile.browserArtifactsDir(profile, env, "/home/tester"),
+    )
+
+    expect(new Set(profiles).size).toBe(5)
+    expect(new Set(artifacts).size).toBe(5)
+    expect(profiles[0]).toBe("/home/tester/.cyberful/browser/profiles/cyberful")
+    expect(profiles[4]).toBe("/home/tester/.cyberful/browser/profiles/cyberful-5")
+  })
+
+  test("prefers numbered overrides while preserving the profile-one legacy override", () => {
+    expect(
+      BrowserProfile.browserProfileDir(
+        1,
+        {
+          CYBER_BROWSER_USER_DATA_DIR: "/legacy/one",
+          CYBER_BROWSER_USER_DATA_DIR_1: "/numbered/one",
+        },
+        "/unused",
+      ),
+    ).toBe("/numbered/one")
+    expect(BrowserProfile.browserProfileDir(1, { CYBER_BROWSER_USER_DATA_DIR: "/legacy/one" }, "/unused")).toBe(
+      "/legacy/one",
+    )
+    expect(BrowserProfile.browserProfileDir(2, { CYBER_BROWSER_USER_DATA_DIR: "/legacy/one" }, "/home/tester")).toBe(
+      "/home/tester/.cyberful/browser/profiles/cyberful-2",
+    )
+  })
+
+  test("builds a headed owned launch for the selected manual profile", () => {
+    const env = BrowserProfile.manualBrowserProfileEnv(
+      2,
+      {
+        PATH: "/usr/bin",
+        CYBER_BROWSER_HEADLESS: "true",
+        CYBER_BROWSER_USER_DATA_DIR_2: "/profiles/two",
+        CYBER_BROWSER_CDP_ENDPOINT: "http://127.0.0.1:9222",
+        CYBER_BROWSER_OWN_TAB: "1",
+        CYBER_BROWSER_SHARED_ATTESTATION: "must-not-cross",
+      },
+      "/home/tester",
+    )
+
+    expect(env).toMatchObject({
+      PATH: "/usr/bin",
+      CYBER_BROWSER_BROWSERS_PATH: "/home/tester/.cyberful/browser/.browsers",
+      CYBER_BROWSER_USER_DATA_DIR: "/profiles/two",
+      CYBER_BROWSER_PROFILE_ID: "2",
+      CYBER_BROWSER_EAGER: "1",
+      CYBER_BROWSER_HEADLESS: "false",
+    })
+    expect(env.CYBER_BROWSER_CDP_ENDPOINT).toBeUndefined()
+    expect(env.CYBER_BROWSER_OWN_TAB).toBeUndefined()
+    expect(env.CYBER_BROWSER_SHARED_ATTESTATION).toBeUndefined()
+  })
+})

--- a/cyberful/src/dependency/browser-profile.ts
+++ b/cyberful/src/dependency/browser-profile.ts
@@ -1,0 +1,96 @@
+// ── Browser Profile Identity ────────────────────────────────────────
+// Defines the five stable browser identities shared by manual pre-authentication
+// and phase gateways, including legacy profile-one environment compatibility.
+// → cyberful/src/bootstrap-browser.ts — provisions stable browser state defaults.
+// → cyberful/src/subsystem/gateway/server.ts — routes browser tools by profile.
+// @docs/runtimes/browser.md
+// ─────────────────────────────────────────────────────────────────────
+
+import os from "node:os"
+import path from "node:path"
+
+export const BROWSER_PROFILE_IDS = [1, 2, 3, 4, 5] as const
+
+export type BrowserProfileId = (typeof BROWSER_PROFILE_IDS)[number]
+
+export function browserHome(homeDirectory = os.homedir()): string {
+  return path.join(homeDirectory, ".cyberful", "browser")
+}
+
+function configuredPath(env: Readonly<NodeJS.ProcessEnv>, name: string): string | undefined {
+  const value = env[name]?.trim()
+  return value || undefined
+}
+
+// ── Profile One Preserves Existing Authenticated State ──────────────
+// Cyberful historically stored its sole installed profile under `cyberful`, so
+// profile one retains that location and the unsuffixed environment override.
+// Numbered overrides take precedence for a uniform five-profile contract, while
+// profiles two through five receive distinct stable directories by default.
+// This prevents an upgrade from discarding profile-one logins or co-locating two
+// identities in the same Chromium storage and lock boundary.
+// ─────────────────────────────────────────────────────────────────────
+export function browserProfileDir(
+  profile: BrowserProfileId,
+  env: Readonly<NodeJS.ProcessEnv> = process.env,
+  homeDirectory = os.homedir(),
+): string {
+  const numbered = configuredPath(env, `CYBER_BROWSER_USER_DATA_DIR_${profile}`)
+  if (numbered) return numbered
+  if (profile === 1) {
+    const legacy = configuredPath(env, "CYBER_BROWSER_USER_DATA_DIR")
+    if (legacy) return legacy
+  }
+  const directory = profile === 1 ? "cyberful" : `cyberful-${profile}`
+  return path.join(browserHome(homeDirectory), "profiles", directory)
+}
+
+export function browserArtifactsDir(
+  profile: BrowserProfileId,
+  env: Readonly<NodeJS.ProcessEnv> = process.env,
+  homeDirectory = os.homedir(),
+): string {
+  const numbered = configuredPath(env, `CYBER_BROWSER_ARTIFACTS_DIR_${profile}`)
+  if (numbered) return numbered
+  if (profile === 1) {
+    const legacy = configuredPath(env, "CYBER_BROWSER_ARTIFACTS_DIR")
+    if (legacy) return legacy
+  }
+  return path.join(browserHome(homeDirectory), "artifacts", `profile-${profile}`)
+}
+
+// ── Manual Seeding Always Owns Its Persistent Browser ───────────────
+// Profile seeding is a headed, human-owned launch rather than a phase attachment.
+// Host-private CDP and shared-attestation modes must not leak from a surrounding
+// environment or the command could connect to another process and seed the wrong
+// identity. Other documented browser policy remains inherited, while cache,
+// profile identity, eager lifetime, and headed mode are fixed for this boundary.
+// ─────────────────────────────────────────────────────────────────────
+export function manualBrowserProfileEnv(
+  profile: BrowserProfileId,
+  env: Readonly<NodeJS.ProcessEnv> = process.env,
+  homeDirectory = os.homedir(),
+): Record<string, string> {
+  const inherited = Object.fromEntries(
+    Object.entries(env).filter(
+      (entry): entry is [string, string] =>
+        entry[1] !== undefined &&
+        !["CYBER_BROWSER_CDP_ENDPOINT", "CYBER_BROWSER_OWN_TAB", "CYBER_BROWSER_SHARED_ATTESTATION"].includes(entry[0]),
+    ),
+  )
+  return {
+    ...inherited,
+    CYBER_BROWSER_BROWSERS_PATH:
+      configuredPath(env, "CYBER_BROWSER_BROWSERS_PATH") ?? path.join(browserHome(homeDirectory), ".browsers"),
+    CYBER_BROWSER_USER_DATA_DIR: browserProfileDir(profile, env, homeDirectory),
+    CYBER_BROWSER_PROFILE_ID: String(profile),
+    CYBER_BROWSER_EAGER: "1",
+    CYBER_BROWSER_HEADLESS: "false",
+  }
+}
+
+export function isBrowserProfileId(value: unknown): value is BrowserProfileId {
+  return typeof value === "number" && BROWSER_PROFILE_IDS.some((profile) => profile === value)
+}
+
+export * as BrowserProfile from "./browser-profile"

--- a/cyberful/src/subsystem/gateway/browser-env.test.ts
+++ b/cyberful/src/subsystem/gateway/browser-env.test.ts
@@ -11,7 +11,13 @@ import path from "node:path"
 
 // resolveBrowserUpstreamEnv is a pure decision function; importing ./server has no load-time side effects
 // (its DB client is lazy and main() only runs as an entrypoint), so a plain dynamic import is safe here.
-const { loadPrivateGatewayEnvironment, resolveBrowserUpstreamEnv, upstreamProcessEnv } = await import("./server")
+const {
+  browserProfileToolDefinition,
+  loadPrivateGatewayEnvironment,
+  resolveBrowserUpstreamEnv,
+  selectBrowserProfileUpstream,
+  upstreamProcessEnv,
+} = await import("./server")
 
 function environmentValue(name: string): string | undefined {
   return process.env[name]
@@ -36,20 +42,82 @@ test("gateway loads the owner-private environment file before binding its sessio
 // Locks browser-profile routing for the one gateway owned by a phase.
 describe("resolveBrowserUpstreamEnv", () => {
   const TEMP = "/tmp/expert-browser-x"
+  const ARTIFACTS = "/home/u/artifacts"
 
   test("pinned profile with no live holder → reuse it for the login", () => {
-    const r = resolveBrowserUpstreamEnv({ dedicated: "/home/u/.chrome", tempProfileDir: TEMP })
-    expect(r.set).toEqual({ CYBER_BROWSER_USER_DATA_DIR: "/home/u/.chrome" })
+    const r = resolveBrowserUpstreamEnv({
+      dedicated: "/home/u/.chrome",
+      artifactsDir: ARTIFACTS,
+      tempProfileDir: TEMP,
+    })
+    expect(r.set).toEqual({
+      CYBER_BROWSER_USER_DATA_DIR: "/home/u/.chrome",
+      CYBER_BROWSER_ARTIFACTS_DIR: ARTIFACTS,
+    })
   })
 
   test("a locked pinned profile falls back to a per-session temp profile", () => {
-    const r = resolveBrowserUpstreamEnv({ dedicated: "/home/u/.chrome", livePort: 4321, tempProfileDir: TEMP })
-    expect(r.set).toEqual({ CYBER_BROWSER_USER_DATA_DIR: TEMP })
+    const r = resolveBrowserUpstreamEnv({
+      dedicated: "/home/u/.chrome",
+      artifactsDir: ARTIFACTS,
+      livePort: 4321,
+      tempProfileDir: TEMP,
+    })
+    expect(r.set).toEqual({
+      CYBER_BROWSER_USER_DATA_DIR: TEMP,
+      CYBER_BROWSER_ARTIFACTS_DIR: path.join(TEMP, "artifacts"),
+    })
   })
 
   test("nothing set → a per-session temp profile", () => {
-    const r = resolveBrowserUpstreamEnv({ tempProfileDir: TEMP })
-    expect(r.set).toEqual({ CYBER_BROWSER_USER_DATA_DIR: TEMP })
+    const r = resolveBrowserUpstreamEnv({ artifactsDir: ARTIFACTS, tempProfileDir: TEMP })
+    expect(r.set).toEqual({
+      CYBER_BROWSER_USER_DATA_DIR: TEMP,
+      CYBER_BROWSER_ARTIFACTS_DIR: path.join(TEMP, "artifacts"),
+    })
+  })
+})
+
+describe("browser profile tool routing", () => {
+  const definition = {
+    name: "browser_navigate",
+    description: "Open a URL.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: { url: { type: "string" } },
+      required: ["url"],
+    },
+  }
+  const call = async () => ({ content: [] })
+  const candidates = [
+    { def: definition, capability: "browser" as const, browserProfile: 1 as const, call },
+    { def: definition, capability: "browser" as const, browserProfile: 2 as const, call },
+  ]
+
+  test("advertises one optional selector without changing the underlying browser schema", () => {
+    const advertised = browserProfileToolDefinition(definition, [1, 2])
+    expect(advertised.inputSchema).toMatchObject({
+      additionalProperties: false,
+      properties: { profile: { type: "integer", enum: [1, 2], default: 1 } },
+    })
+    expect(definition.inputSchema.properties).not.toHaveProperty("profile")
+  })
+
+  test("defaults to profile one and strips the gateway-only selector before forwarding", () => {
+    expect(selectBrowserProfileUpstream(candidates, { url: "https://example.test" })).toEqual({
+      upstream: candidates[0],
+      args: { url: "https://example.test" },
+    })
+    expect(selectBrowserProfileUpstream(candidates, { profile: 2, url: "https://example.test" })).toEqual({
+      upstream: candidates[1],
+      args: { url: "https://example.test" },
+    })
+  })
+
+  test("rejects invalid or unavailable profile identities", () => {
+    expect(() => selectBrowserProfileUpstream(candidates, { profile: "2" })).toThrow("integer from 1 through 5")
+    expect(() => selectBrowserProfileUpstream(candidates, { profile: 5 })).toThrow("profile 5 is unavailable")
   })
 })
 

--- a/cyberful/src/subsystem/gateway/server.test.ts
+++ b/cyberful/src/subsystem/gateway/server.test.ts
@@ -477,6 +477,58 @@ describe("expert-gateway cyberful-os/browser proxy", () => {
     }
   })
 
+  test("advertises one browser tool and routes calls to isolated numbered profiles", async () => {
+    const calls: { profile: number; args: Record<string, unknown> }[] = []
+    const browserTool = (profile: 1 | 2): UpstreamTool => ({
+      def: {
+        name: "browser_navigate",
+        description: "Open a URL.",
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: { url: { type: "string" } },
+          required: ["url"],
+        },
+      },
+      capability: "browser",
+      browserProfile: profile,
+      call: async (args) => {
+        calls.push({ profile, args })
+        return { content: [{ type: "text", text: JSON.stringify({ profile }) }] }
+      },
+    })
+    const server = await createGatewayServer({ upstreams: [browserTool(1), browserTool(2)] })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    await server.connect(serverTransport)
+    const browserClient = new Client({ name: "browser-profile-test", version: "0" })
+    await browserClient.connect(clientTransport)
+    try {
+      const browserDefinitions = (await browserClient.listTools()).tools.filter(
+        (tool) => tool.name === "browser_navigate",
+      )
+      expect(browserDefinitions).toHaveLength(1)
+      expect(browserDefinitions[0]?.inputSchema).toMatchObject({
+        properties: { profile: { type: "integer", enum: [1, 2], default: 1 } },
+      })
+
+      await browserClient.callTool({
+        name: "browser_navigate",
+        arguments: { profile: 2, url: "https://example.test/account" },
+      })
+      await browserClient.callTool({
+        name: "browser_navigate",
+        arguments: { url: "https://example.test/default" },
+      })
+      expect(calls).toEqual([
+        { profile: 2, args: { url: "https://example.test/account" } },
+        { profile: 1, args: { url: "https://example.test/default" } },
+      ])
+    } finally {
+      await browserClient.close()
+      await server.closeGateway()
+    }
+  })
+
   test("applies the advertised max_output_bytes ceiling once before an upstream executes", async () => {
     let received: Record<string, unknown> | undefined
     const bounded: UpstreamTool = {

--- a/cyberful/src/subsystem/gateway/server.ts
+++ b/cyberful/src/subsystem/gateway/server.ts
@@ -14,6 +14,7 @@ import { randomUUID } from "node:crypto"
 import { readFile, rename, rm, writeFile } from "node:fs/promises"
 import { SubsystemPhase } from "../phase"
 import { SubsystemBrowserCdp } from "../browser-cdp"
+import { BrowserProfile, type BrowserProfileId } from "@/dependency/browser-profile"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import {
@@ -934,7 +935,66 @@ function handleVariable(sessionID: SessionID, args: Record<string, unknown>) {
 export interface UpstreamTool {
   def: { name: string; description?: string; inputSchema: unknown }
   capability?: SubsystemPhase.WorkflowCapability
+  browserProfile?: BrowserProfileId
   call(args: Record<string, unknown>): Promise<CallToolResult>
+}
+
+// ── One Browser Surface Selects Five Isolated Identities ────────────
+// Repeating every browser tool five times would obscure the useful tool surface
+// and weaken existing prompts that already know the `browser_*` names. The
+// gateway instead adds one bounded profile selector to each browser schema and
+// removes it before forwarding the call to that profile's unmodified MCP tool.
+// Profile one remains the default, preserving existing calls while natural
+// references such as "the second browser profile" map directly to `profile: 2`.
+// ─────────────────────────────────────────────────────────────────────
+export function browserProfileToolDefinition(
+  definition: UpstreamTool["def"],
+  profiles: readonly BrowserProfileId[],
+): UpstreamTool["def"] {
+  if (!isRecord(definition.inputSchema)) return definition
+  const properties = isRecord(definition.inputSchema.properties) ? definition.inputSchema.properties : {}
+  return {
+    ...definition,
+    description: `${definition.description ?? "Use the isolated browser."} Select profile 1-5 for a distinct authenticated browser identity; profile 1 is the default.`,
+    inputSchema: {
+      ...definition.inputSchema,
+      properties: {
+        ...properties,
+        profile: {
+          type: "integer",
+          enum: profiles,
+          default: 1,
+          description: "Isolated browser identity: 1 is the first profile, through 5 for the fifth profile.",
+        },
+      },
+    },
+  }
+}
+
+export function selectBrowserProfileUpstream(
+  candidates: readonly UpstreamTool[],
+  args: Record<string, unknown>,
+): { upstream: UpstreamTool; args: Record<string, unknown> } {
+  const profiled = candidates.filter(
+    (candidate): candidate is UpstreamTool & { browserProfile: BrowserProfileId } =>
+      candidate.browserProfile !== undefined,
+  )
+  if (profiled.length === 0) {
+    const upstream = candidates[0]
+    if (!upstream) throw new Error("browser tool has no available upstream")
+    return { upstream, args }
+  }
+
+  const requested = args.profile ?? 1
+  if (!BrowserProfile.isBrowserProfileId(requested)) {
+    throw new Error("browser profile must be an integer from 1 through 5")
+  }
+  const upstream = profiled.find((candidate) => candidate.browserProfile === requested)
+  if (!upstream) throw new Error(`browser profile ${requested} is unavailable`)
+  return {
+    upstream,
+    args: Object.fromEntries(Object.entries(args).filter(([name]) => name !== "profile")),
+  }
 }
 
 interface ToolArgumentAdjustment {
@@ -1062,15 +1122,6 @@ function proxyEnabled(): boolean {
   return v === "1" || v === "true" || v === "yes"
 }
 
-function agentBrowserProfileDir(): string {
-  if (process.env.CYBER_BROWSER_USER_DATA_DIR) return process.env.CYBER_BROWSER_USER_DATA_DIR
-  const stateHome = process.env.XDG_STATE_HOME || path.join(os.homedir(), ".local", "state")
-  return path.join(stateHome, "cyberful-os", "mcp", "browser", "profile")
-}
-async function readAgentCdpPort(): Promise<number | undefined> {
-  return SubsystemBrowserCdp.readCdpPort(agentBrowserProfileDir())
-}
-
 // ── Profile Choice Avoids Browser Lock Contention ────────────────
 // A persistent browser context locks its user-data directory, so another process
 // must not launch against a profile with a live CDP holder. The caller performs
@@ -1079,14 +1130,31 @@ async function readAgentCdpPort(): Promise<number | undefined> {
 // login; every other state falls back to a per-run profile whose lock cannot
 // collide with another phase or an orphaned browser.
 // ─────────────────────────────────────────────────────────────────
-export function resolveBrowserUpstreamEnv(input: { dedicated?: string; livePort?: number; tempProfileDir: string }): {
+export function resolveBrowserUpstreamEnv(input: {
+  dedicated?: string
+  artifactsDir: string
+  livePort?: number
+  tempProfileDir: string
+}): {
   set: Record<string, string>
   unset: string[]
 } {
   if (input.dedicated && !input.livePort) {
-    return { set: { CYBER_BROWSER_USER_DATA_DIR: input.dedicated }, unset: [] }
+    return {
+      set: {
+        CYBER_BROWSER_USER_DATA_DIR: input.dedicated,
+        CYBER_BROWSER_ARTIFACTS_DIR: input.artifactsDir,
+      },
+      unset: [],
+    }
   }
-  return { set: { CYBER_BROWSER_USER_DATA_DIR: input.tempProfileDir }, unset: [] }
+  return {
+    set: {
+      CYBER_BROWSER_USER_DATA_DIR: input.tempProfileDir,
+      CYBER_BROWSER_ARTIFACTS_DIR: path.join(input.tempProfileDir, "artifacts"),
+    },
+    unset: [],
+  }
 }
 
 // ── Upstreams Receive Least-Privilege Environments ───────────────
@@ -1130,12 +1198,20 @@ async function connectDefaultUpstreams(upstreamDiagnosticSink?: (text: string) =
   const out: UpstreamTool[] = []
   const clients: Client[] = []
   const bridgeContainers = new Set<string>()
-  const upstreamCapabilities = [
-    ["cyberful-os", "isolated-exec"],
-    ["browser", "browser"],
-    ["zap", "zap"],
-  ] as const satisfies readonly (readonly [string, SubsystemPhase.WorkflowCapability])[]
-  for (const [key, capability] of upstreamCapabilities) {
+  const upstreamCapabilities: readonly {
+    readonly key: "cyberful-os" | "browser" | "zap"
+    readonly capability: SubsystemPhase.WorkflowCapability
+    readonly browserProfile?: BrowserProfileId
+  }[] = [
+    { key: "cyberful-os", capability: "isolated-exec" },
+    ...BrowserProfile.BROWSER_PROFILE_IDS.map((browserProfile) => ({
+      key: "browser" as const,
+      capability: "browser" as const,
+      browserProfile,
+    })),
+    { key: "zap", capability: "zap" },
+  ]
+  for (const { key, capability, browserProfile } of upstreamCapabilities) {
     const workflow = selectedWorkflow()
     if (!activeWorkflowPhase(workflow) || !workflow || !SubsystemPhase.hasCapability(workflow, capability)) continue
     if (!activeRuntimeAllowed(capability)) continue
@@ -1145,16 +1221,21 @@ async function connectDefaultUpstreams(upstreamDiagnosticSink?: (text: string) =
       if (key === "zap" && "container" in def && def.container) bridgeContainers.add(def.container)
       const [cmd, ...args] = def.command
       const env = upstreamProcessEnv(key, process.env, def.environment)
-      if (key === "browser") {
-        const dedicated = process.env.CYBER_BROWSER_USER_DATA_DIR
-        const livePort = dedicated ? await readAgentCdpPort() : undefined
+      if (key === "browser" && browserProfile !== undefined) {
+        const dedicated = BrowserProfile.browserProfileDir(browserProfile)
+        const livePort = await SubsystemBrowserCdp.readCdpPort(dedicated)
         const { set, unset } = resolveBrowserUpstreamEnv({
           dedicated,
+          artifactsDir: BrowserProfile.browserArtifactsDir(browserProfile),
           livePort,
-          tempProfileDir: path.join(os.tmpdir(), `expert-browser-${boundSession()}-${process.pid}`),
+          tempProfileDir: path.join(
+            os.tmpdir(),
+            `expert-browser-${boundSession()}-${process.pid}-profile-${browserProfile}`,
+          ),
         })
         for (const [k, v] of Object.entries(set)) env[k] = v
         for (const k of unset) delete env[k]
+        env.CYBER_BROWSER_PROFILE_ID = String(browserProfile)
         const policy = runtimePolicy(boundSession(), selectedWorkflow())
         if (policy) env.CYBER_BROWSER_ALLOWED_ORIGINS = JSON.stringify(policy.origins)
       }
@@ -1203,7 +1284,10 @@ async function connectDefaultUpstreams(upstreamDiagnosticSink?: (text: string) =
           try {
             upstreamDiagnosticSink(chunk.toString("utf8"))
           } catch (error) {
-            log.warn("upstream diagnostic sink failed", { upstream: key, error })
+            log.warn("upstream diagnostic sink failed", {
+              upstream: browserProfile === undefined ? key : `${key}-${browserProfile}`,
+              error,
+            })
           }
         })
       }
@@ -1212,10 +1296,11 @@ async function connectDefaultUpstreams(upstreamDiagnosticSink?: (text: string) =
       clients.push(client)
       const { tools } = await client.listTools()
       for (const t of tools) {
-        if (out.some((u) => u.def.name === t.name)) continue
+        if (browserProfile === undefined && out.some((u) => u.def.name === t.name)) continue
         out.push({
           def: t,
           capability,
+          ...(browserProfile === undefined ? {} : { browserProfile }),
           // ── Tool Calls Share One Explicit Ten-Minute Ceiling ─────────────
           // Authorized scanners can legitimately run beyond the MCP SDK's
           // one-minute default. The gateway and Codex registration therefore
@@ -1234,7 +1319,10 @@ async function connectDefaultUpstreams(upstreamDiagnosticSink?: (text: string) =
       }
     } catch (error) {
       if (key === "cyberful-os") throw error
-      log.warn("optional phase gateway upstream is unavailable", { upstream: key, error })
+      log.warn("optional phase gateway upstream is unavailable", {
+        upstream: browserProfile === undefined ? key : `${key}-${browserProfile}`,
+        error,
+      })
     }
   }
   return {
@@ -1278,7 +1366,20 @@ export async function createGatewayServer(opts?: {
       ? await connectDefaultUpstreams(opts?.upstreamDiagnosticSink)
       : { tools: [], clients: [], close: () => Promise.resolve() }
   const upstreams = connected.tools
-  const byName = new Map(upstreams.map((u) => [u.def.name, u]))
+  const byName = new Map<string, UpstreamTool[]>()
+  for (const upstream of upstreams) {
+    const candidates = byName.get(upstream.def.name) ?? []
+    candidates.push(upstream)
+    byName.set(upstream.def.name, candidates)
+  }
+  const upstreamDefinitions = Array.from(byName.values(), (candidates) => {
+    const definition = candidates[0]?.def
+    if (!definition) throw new Error("gateway upstream group has no tool definition")
+    const profiles = candidates.flatMap((candidate) =>
+      candidate.browserProfile === undefined ? [] : [candidate.browserProfile],
+    )
+    return profiles.length > 0 ? browserProfileToolDefinition(definition, profiles) : definition
+  })
   const localTools = localToolDefinitions()
   const localToolNames = new Set<string>(localTools.map((tool) => tool.name))
   const codeGraph = localTools.some((tool) => isCodeGraphTool(tool.name))
@@ -1319,7 +1420,7 @@ export async function createGatewayServer(opts?: {
       ...(question ? [QUESTION_TOOL_DEF] : []),
       ...(handoff ? [handoffToolDef(handoff)] : []),
       ...localTools,
-      ...upstreams.map((u) => u.def),
+      ...upstreamDefinitions,
     ],
   }))
 
@@ -1397,8 +1498,8 @@ export async function createGatewayServer(opts?: {
         return text({ error: error instanceof Error ? error.message : String(error) }, true)
       }
     }
-    const upstream = byName.get(name)
-    if (!upstream) return text({ error: `unknown tool ${name}` })
+    const candidates = byName.get(name)
+    if (!candidates) return text({ error: `unknown tool ${name}` })
     const breakerError = circuit ? await circuitBreakerError(circuit.filePath, name) : undefined
     if (breakerError) return text({ error: breakerError }, true)
     const policyError = zapPhaseToolError(process.env.CYBERFUL_SUBSYSTEM_PHASE?.trim(), name)
@@ -1413,7 +1514,14 @@ export async function createGatewayServer(opts?: {
       return text({ error: policyError }, true)
     }
     const resolvedArgs = resolveArgs(sessionID, name, args)
-    const adjusted = adjustUpstreamArguments(upstream.def, resolvedArgs)
+    let selected: ReturnType<typeof selectBrowserProfileUpstream>
+    try {
+      selected = selectBrowserProfileUpstream(candidates, resolvedArgs)
+    } catch (error) {
+      return text({ error: error instanceof Error ? error.message : String(error) }, true)
+    }
+    const upstream = selected.upstream
+    const adjusted = adjustUpstreamArguments(upstream.def, selected.args)
     if (
       (upstream.capability === "browser" || upstream.capability === "zap") &&
       (selectedWorkflow() === "assessment" || selectedWorkflow() === "remediate")

--- a/cyberful/src/subsystem/phase-runner.test.ts
+++ b/cyberful/src/subsystem/phase-runner.test.ts
@@ -183,6 +183,24 @@ describe("runPhase transcript persistence", () => {
     expect(skillRoots).toEqual(["/tmp/skills"])
   })
 
+  test("the phase prompt maps account descriptions to isolated browser profile selectors", async () => {
+    let prompt = ""
+    await SubsystemPhaseRunner.runPhase(
+      spec(),
+      deps({
+        run: async (input) => {
+          prompt = input.prompt
+          return { stdout: "{}", stderr: "", exitCode: 0, timedOut: false }
+        },
+      }),
+    )
+
+    expect(prompt).toContain("optional integer `profile` from 1 through 5")
+    expect(prompt).toContain("first, second")
+    expect(prompt).toContain("`profile: 1`, `profile: 2`, or `profile: 5`")
+    expect(prompt).toContain("Never copy session material between them")
+  })
+
   test("keeps shell temporary files inside the workarea", async () => {
     let env: Record<string, string> | undefined
     let privateEnv: Record<string, string> | undefined

--- a/cyberful/src/subsystem/phase-runner.ts
+++ b/cyberful/src/subsystem/phase-runner.ts
@@ -471,6 +471,10 @@ function buildPhasePrompt(spec: PhaseSpec, budgetMinutes: number): string {
     "  boundary: everything stays under the workarea.",
     "- Persist reusable or secret values (tokens, a target base URL, IDs) as session variables via your",
     "  variable tool, and reference them as {{var:name}} in later tool arguments instead of raw values.",
+    "- Every `browser_*` tool accepts an optional integer `profile` from 1 through 5; omitted means profile 1.",
+    "  Each number is a distinct persistent cookie/storage identity. Treat user wording such as first, second,",
+    "  or fifth browser profile as `profile: 1`, `profile: 2`, or `profile: 5` respectively, and keep every",
+    "  account's actions and evidence labelled with that profile number. Never copy session material between them.",
     "- When a blocking choice, authorization, or missing fact genuinely requires the human, call",
     "  `question` and continue from the answer shown through the TUI. Do not ask only in prose and stop.",
     "- CAPTCHA is a host-enforced circuit breaker. First perform only the normal user action that makes",
@@ -983,16 +987,16 @@ export async function runPhase(spec: PhaseSpec, deps: PhaseDeps = defaultDeps())
     ? !gatewayExited
       ? "Code Audit index readiness was not evaluated because the phase gateway is still live; trace is blocked."
       : deps.verifyCodeGraphReadiness
-      ? await deps
-          .verifyCodeGraphReadiness({
-            ...spec.env,
-            CYBERFUL_SUBSYSTEM_WORKAREA_ROOT: spec.workareaCwd,
-            ...(spec.workflow ? { CYBERFUL_SUBSYSTEM_WORKFLOW: spec.workflow } : {}),
-            ...(spec.sourceRoot ? { CYBERFUL_SUBSYSTEM_SOURCE_ROOT: spec.sourceRoot } : {}),
-          })
-          .then(() => undefined)
-          .catch((error) => `Code Audit index readiness failed; trace is blocked: ${errorDetail(error)}`)
-      : "Code Audit index readiness verifier is unavailable; trace is blocked."
+        ? await deps
+            .verifyCodeGraphReadiness({
+              ...spec.env,
+              CYBERFUL_SUBSYSTEM_WORKAREA_ROOT: spec.workareaCwd,
+              ...(spec.workflow ? { CYBERFUL_SUBSYSTEM_WORKFLOW: spec.workflow } : {}),
+              ...(spec.sourceRoot ? { CYBERFUL_SUBSYSTEM_SOURCE_ROOT: spec.sourceRoot } : {}),
+            })
+            .then(() => undefined)
+            .catch((error) => `Code Audit index readiness failed; trace is blocked: ${errorDetail(error)}`)
+        : "Code Audit index readiness verifier is unavailable; trace is blocked."
     : undefined
   const budgetAdvanceWarning =
     rawTermination === "budget_exhausted" &&

--- a/docs/runtimes/browser.md
+++ b/docs/runtimes/browser.md
@@ -1,20 +1,54 @@
 # Browser MCP
 
-The browser MCP drives an isolated, headed Chromium profile by default and
-exposes structured DOM, page, network, cookie, and artifact operations. It does
-not provide screenshot or vision tools and does not solve CAPTCHAs.
+The browser MCP drives up to five isolated, headed Chromium profiles and exposes
+structured DOM, page, network, cookie, and artifact operations. It does not
+provide screenshot or vision tools and does not solve CAPTCHAs. Every
+`browser_*` tool accepts an optional integer `profile` from `1` through `5`;
+omitting it selects profile 1.
+
+Each number owns separate cookies, local storage, cache, tabs, downloads, and a
+Chromium profile lock. This makes role-to-role and tenant-to-tenant comparisons
+possible without moving session tokens between accounts. A mission can say, for
+example, "profile 1 contains the buyer and profile 2 the seller"; Cyberful maps
+those identities to `profile: 1` and `profile: 2` on every browser call.
+
+## Pre-authenticate profiles manually
+
+From the repository root, open the identity you want to seed:
+
+```sh
+make browser-run-1
+make browser-run-2
+# ...through make browser-run-5
+```
+
+Sign in only to the authorized target account for that identity, then fully
+close the Chromium window. The Make command returns after the browser exits and
+releases its profile lock. Repeat for other accounts, then run Cyberful and tell
+it which account is stored in each numbered profile. Do not leave a manual
+profile open when starting Cyberful: a locked profile is replaced with a
+temporary unauthenticated fallback for that run rather than risking corruption.
+
+The default persistent locations are
+`~/.cyberful/browser/profiles/cyberful` for profile 1 and
+`~/.cyberful/browser/profiles/cyberful-2` through `cyberful-5` for the remaining
+identities. Never point any profile at a personal daily-use browser directory.
 
 The installed binary downloads open-source Chromium on first use and stores it
-in the Cyberful cache. To reuse an explicitly prepared Google Chrome profile for
-an authorized target, set in the launch directory's `.env`:
+in the Cyberful cache. To use real Google Chrome for all five identities, or
+override one explicitly prepared profile, set values in the launch directory's
+`.env`:
 
 ```dotenv
 CYBER_BROWSER_CHANNEL=chrome
-CYBER_BROWSER_USER_DATA_DIR=/absolute/path/to/dedicated-profile
+CYBER_BROWSER_USER_DATA_DIR_2=/absolute/path/to/dedicated-profile-2
 ```
 
-Fully close the seeded browser before Cyberful starts so its profile lock is
-released. Never point Cyberful at a personal daily-use profile. Chromium is the
+`CYBER_BROWSER_USER_DATA_DIR` remains the compatibility override for profile 1;
+`CYBER_BROWSER_USER_DATA_DIR_1` through `_5` are the numbered overrides and take
+precedence. Matching `CYBER_BROWSER_ARTIFACTS_DIR_1` through `_5` values can
+override each download directory. Fully close every seeded browser before
+Cyberful starts so its profile lock is released. Chromium is the
 distribution-safe default; `CYBER_BROWSER_CHANNEL=auto` prefers Chrome when it
 is installed.
 

--- a/mcps/README.md
+++ b/mcps/README.md
@@ -198,11 +198,14 @@ Chromium. It does **not** auto-solve CAPTCHAs — real challenges still go throu
 
 ### Isolation
 
-Everything the browser persists lives outside the user's own Chrome profile:
+Everything the browser persists lives outside the user's own Chrome profile.
+Cyberful exposes five identities through the optional `profile: 1..5` argument
+on every `browser_*` tool; each MCP process still owns one profile:
 
 - Browser cache: `mcps/browser/.browsers`
-- Profile: `~/.local/state/cyberful-os/mcp/browser/profile`
-- Artifacts: `~/.local/state/cyberful-os/mcp/browser/artifacts`
+- Installed profiles: `~/.cyberful/browser/profiles/cyberful{,-2,-3,-4,-5}`
+- Installed artifacts: `~/.cyberful/browser/artifacts/profile-{1..5}`
+- Standalone MCP defaults: `~/.local/state/cyberful-os/mcp/browser/{profile,artifacts}`
 
 ### Environment overrides
 
@@ -211,8 +214,10 @@ Everything the browser persists lives outside the user's own Chrome profile:
 - `CYBER_BROWSER_HEADLESS` — default `false`; `=true` runs Chromium headless
 - `CYBER_BROWSER_BROWSERS_PATH` — Chromium install/cache location
 - `CYBER_BROWSER_USER_DATA_DIR` — persistent profile dir
+- `CYBER_BROWSER_USER_DATA_DIR_1` … `_5` — per-identity profile dirs (`_1` takes precedence over the legacy unsuffixed value)
 - `CYBER_BROWSER_CLEAR_COOKIES_ON_START` — default `false`; set `true` only to discard the dedicated profile's target login
 - `CYBER_BROWSER_ARTIFACTS_DIR` — saved artifacts / downloads
+- `CYBER_BROWSER_ARTIFACTS_DIR_1` … `_5` — per-identity artifact dirs
 - `CYBER_BROWSER_EXECUTABLE` — use a specific Chromium/Chrome binary
 - `CYBER_BROWSER_PROXY` — route the browser through a proxy
 - `CYBER_BROWSER_STEALTH` — default `true`; `=false` reverts to the stock driver + bundled Chromium

--- a/mcps/browser/README.md
+++ b/mcps/browser/README.md
@@ -3,6 +3,10 @@
 Standalone stdio MCP server for browser-use style automation with an isolated
 Playwright Chromium on macOS.
 
+Cyberful starts one instance per numbered browser identity and adds the
+gateway-only `profile` selector to the tools. A standalone MCP process still
+owns exactly one `CYBER_BROWSER_USER_DATA_DIR`.
+
 ## Install
 
 From the repository root:
@@ -101,6 +105,7 @@ Useful environment overrides:
 
 - `CYBER_BROWSER_BROWSERS_PATH`
 - `CYBER_BROWSER_USER_DATA_DIR`
+- `CYBER_BROWSER_PROFILE_ID` as an integer from `1` through `5` reported by `browser_status`
 - `CYBER_BROWSER_CLEAR_COOKIES_ON_START=true` to intentionally clear the persistent target login (default: preserve it)
 - `CYBER_BROWSER_ARTIFACTS_DIR`
 - `CYBER_BROWSER_HEADLESS=true`

--- a/mcps/browser/browser_mcp.mjs
+++ b/mcps/browser/browser_mcp.mjs
@@ -80,6 +80,7 @@ const USER_DATA_DIR =
 const ARTIFACTS_DIR =
   process.env.CYBER_BROWSER_ARTIFACTS_DIR || path.join(STATE_HOME, "cyberful-os", "mcp", "browser", "artifacts")
 const ALLOWED_ORIGINS = parseBrowserAllowedOrigins(process.env.CYBER_BROWSER_ALLOWED_ORIGINS)
+const PROFILE_ID = envInt("CYBER_BROWSER_PROFILE_ID", 1, 1, 5)
 
 if (!process.env.PLAYWRIGHT_BROWSERS_PATH) {
   process.env.PLAYWRIGHT_BROWSERS_PATH = BROWSERS_PATH
@@ -1750,6 +1751,7 @@ registerTool(
         chromium_executable: executablePath,
         chromium_installed: executableExists,
         browser_cache: BROWSERS_PATH,
+        profile: PROFILE_ID,
         user_data_dir: USER_DATA_DIR,
         artifacts_dir: ARTIFACTS_DIR,
         headless: envBool("CYBER_BROWSER_HEADLESS", false),


### PR DESCRIPTION
## Summary

- add five persistent, isolated browser identities with separate cookies, storage, tabs, downloads, and profile locks
- add an optional `profile: 1..5` selector to every existing `browser_*` tool while preserving profile 1 as the default
- add `make browser-run-1` through `make browser-run-5` for manual target pre-authentication
- preserve the previous profile-one directory and legacy environment overrides
- teach phase prompts, Recon, and the ZAP workflow to retain explicit account-to-profile mappings
- document numbered profile and artifact overrides

## Why

Authorized IDOR, tenant-boundary, and cross-account testing needs multiple authenticated browser identities without copying session material between accounts or expanding the MCP tool catalog fivefold.

## User impact

Users can pre-authenticate up to five accounts, close the seeded browser windows, and describe the account-to-profile mapping in the Cyberful prompt. Existing calls without a profile continue to use profile 1.

## Verification

- [x] `make test-bun`: 599 application tests and 20 browser MCP tests passed
- [x] focused gateway/profile/phase tests: 70 passed
- [x] `bun run typecheck`
- [x] `make docs-build`
- [x] Prettier, CODE.md verification, and `git diff --check`

## Security and release impact

- [x] The change stays within Cyberful's authorization and no-telemetry boundaries.
- [x] No credentials, engagement data, transcripts, reports, browser profiles, or runtime state are included.
- [x] Tests cover behavior changes and documentation is updated where required.
- [x] No new or redistributed dependencies or assets are introduced.
