### PR TITLE
Implemented a broader, autonomous fallback inference flow.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,12 +43,13 @@ process and gateway must exit before the successor starts. Native Codex
 delegation is persona-controlled: only Ultra plus a positive `subagents`
 frontmatter value permits direct children, which remain inside the phase's
 workarea and gateway. An optional operator-owned loopback Responses server may
-provide one bounded helper and one security-policy recovery per phase through
-the `AgenticSubsystemAdapter` contract. It must inherit the same scope,
-workarea, controls, approval ledger, and remaining budget; it is not a
+provide serialized, model-initiated assistance and one recovery for each
+recoverable primary execution through the `AgenticSubsystemAdapter` contract.
+Calls have no numeric cap but must inherit the same scope, workarea, controls,
+approval ledger, and remaining budget; fallback cannot recurse and is not a
 user-selectable replacement for the primary chain. Do not introduce host-owned
-phase fan-out, hidden delegation, or another unconstrained production model
-path. See [`docs/runtimes/fallback-inference.md`](docs/runtimes/fallback-inference.md).
+phase fan-out, hidden delegation, or another unconstrained production model path.
+See [`docs/runtimes/fallback-inference.md`](docs/runtimes/fallback-inference.md).
 
 ## Operational constraints
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,8 +4,9 @@ The terminal application is a local control plane around Codex as its primary
 model executor. Session storage, orchestration, policy, MCP lifecycle, and
 reporting are host responsibilities; primary model reasoning occurs in one
 ephemeral Codex process per phase. An optional operator-owned loopback Responses
-server can run a bounded helper or one-shot recovery through the same subsystem
-contract.
+server can run bounded delegated operations or a one-shot recovery through the
+same subsystem contract. Delegations are serialized and may repeat while phase
+budget remains.
 
 ## Runtime shape
 
@@ -20,9 +21,9 @@ TUI input
   -> workarea artifacts
   -> validated successor
 
-Structured terminal cyberPolicy failure
-  -> primary process and gateway fully reaped
-  -> one local fallback recovery with an aggressive-recovery gateway
+Recoverable primary failure or incomplete output contract
+  -> primary process and gateway fully reaped and outputs collected
+  -> one local fallback recovery with a fallback-recovery gateway
   -> validated deliverable and handoff, or preserved dual failure
 ```
 
@@ -59,22 +60,31 @@ For each sequential phase the orchestrator:
 8. proves the process and gateway tree have exited, then seals the final artifact with a host-generated
    SHA-256 manifest before launching the successor.
 
-When configured, one voluntary helper may temporarily suspend the primary turn,
-use an `aggressive-assist` gateway, and return a compact result without owning
-the phase handoff. Only a terminal failed turn classified structurally as
-`codexErrorInfo === "cyberPolicy"` can trigger automatic recovery. Cyberful
-first collects the primary process and gateway, then starts one fresh local
-process, nonce, gateway, and transcript in the same phase, workarea, scope, and
-remaining active budget. The recovery receives a sanitized capsule capped at
-16 KiB and may own the handoff; it cannot recursively invoke fallback. Approval
-waits remain outside the active budget.
+When configured and reachable, the primary receives a conditional nudge and may
+call `delegate_to_fallback_inference` whenever an authorized action needs a more
+aggressive approach that it cannot execute. Calls are serialized, have distinct
+attempt numbers, gateways, and transcripts, and have no numeric cap while phase
+budget remains. A `fallback-assist` returns a compact result without owning the
+phase handoff or seeing the delegation tool itself.
 
-Both fallback profiles use default-deny, versioned first-party tool sets. They retain
-active security, shell, evidence, browser, approval, rate-limit, and
-circuit-breaker controls while omitting recon inventory and report generators
-to reduce prefill noise. `handoff` appears only in recovery. Because shell
-remains general, this selection is an interface reduction rather than a
-security boundary.
+After collecting the complete primary result, Cyberful may start one automatic
+recovery for a provider failure, empty effective summary, missing deliverable,
+or missing/invalid handoff. Cancellation, shutdown, exhausted budget, spawn or
+setup failure, a live primary gateway, and host cleanup, sealing, or readiness
+failures do not qualify. The fresh `fallback-recovery` session inherits the
+phase, workarea, scope, approval ledger, controls, and remaining active budget;
+it receives a sanitized 16 KiB capsule, may own handoff, and cannot recurse.
+Structured `cyberPolicy` blocks remain one provider-failure use case rather than
+the only trigger. Approval waits remain outside the active budget.
+
+Both fallback profiles use default-deny, versioned first-party tool sets. Assist
+eagerly receives shell plus compact evidence/discovery, browser, approval,
+rate-limit, and circuit-breaker controls; it discovers dedicated container
+commands through a narrow `tool_inventory` query only when needed. Recovery
+also receives active security tools because it may own the interrupted phase.
+Both omit recon inventory and report generators, and `handoff` appears only in
+recovery. Because shell remains general, this selection is an interface
+reduction rather than a security boundary.
 
 The phase runner supplies Markdown cleanup with only the required deliverable
 path; it never traverses the complete workarea. Code Audit also verifies a

--- a/README.md
+++ b/README.md
@@ -164,9 +164,11 @@ evidence from the validated ledger.
 - `mcps/zap/` — headless OWASP ZAP runtime and bridge for Pentest.
 
 Codex is the primary backend. An operator may attach a pre-started loopback
-Responses server as one bounded helper and one security-policy recovery attempt
-per phase. It inherits the same scope, workarea, controls, approval ledger, and
-remaining budget; it is not a replacement backend or an independent workflow.
+Responses server as an optional local delegate. The primary can invoke it
+serially whenever an authorized operation needs a more aggressive approach that
+the primary cannot execute; the host may also run one automatic recovery after
+a recoverable primary failure. It inherits the same scope, workarea, controls,
+approval ledger, and remaining budget, and is not a replacement backend.
 
 Cyberful emits no outbound telemetry, metrics, or analytics.
 

--- a/cyberful/src/cli/cmd/tui/context/expert-feed.test.ts
+++ b/cyberful/src/cli/cmd/tui/context/expert-feed.test.ts
@@ -12,6 +12,7 @@ import {
   expertActorCardLabel,
   expertActorStateText,
   expertActorTextLabel,
+  expertActorTone,
   expertPhaseDuration,
   expertPhaseLabel,
   foldExpertActivity,
@@ -187,6 +188,8 @@ describe("foldExpertActivity", () => {
       status: "completed",
     })
     expect(expertActorStateText("interacted")).toBe("received follow-up")
+    expect(expertActorTone(actor)).toBe("default")
+    expect(expertActorTone({ id: "fallback-assist-1", role: "fallback" })).toBe("warning")
   })
 
   test("equal native call ids from simultaneous subsystems do not merge", () => {

--- a/cyberful/src/cli/cmd/tui/context/expert-feed.ts
+++ b/cyberful/src/cli/cmd/tui/context/expert-feed.ts
@@ -89,6 +89,10 @@ export function expertActorTextLabel(label: string): string {
   return `@${label} → `
 }
 
+export function expertActorTone(actor: PhaseActivityActor | undefined): "default" | "warning" {
+  return actor?.role === "fallback" ? "warning" : "default"
+}
+
 export function isExpertSemanticProgress(text: string): boolean {
   try {
     const value: unknown = JSON.parse(text)
@@ -157,9 +161,7 @@ function phaseStatusText(status: ExpertPhaseStatus): string {
   const elapsed = (status.durationMs / 1000).toFixed(1)
   const limit = (status.limitMs / 60_000).toFixed(1)
   const effective = (status.effectiveLimitMs / 60_000).toFixed(1)
-  const approvalWait = status.approvalWaitMs
-    ? ` · approval wait ${expertPhaseDuration(status.approvalWaitMs)}`
-    : ""
+  const approvalWait = status.approvalWaitMs ? ` · approval wait ${expertPhaseDuration(status.approvalWaitMs)}` : ""
   const warning = status.warnings[0]
     ? ` · ${status.warnings[0]}${status.warnings.length > 1 ? ` (+${status.warnings.length - 1})` : ""}`
     : ""

--- a/cyberful/src/cli/cmd/tui/routes/session/index.tsx
+++ b/cyberful/src/cli/cmd/tui/routes/session/index.tsx
@@ -27,6 +27,7 @@ import {
   expertActorCardLabel,
   expertActorStateText,
   expertActorTextLabel,
+  expertActorTone,
   expertPhaseDuration,
   expertPhaseLabel,
   isExpertSemanticProgress,
@@ -1264,11 +1265,13 @@ function ExpertPhaseRow(props: {
     props.workflow ? SubsystemPhase.phaseOwner(props.workflow, props.entry.phase) === "expert" : false
   const markerColor = () => (isExpert() ? theme.info : theme.textMuted)
   const actorLabel = () => props.entry.actor?.label
-  const actorLabelColor = () => tint(theme.textMuted, theme.text, 0.12)
+  const fallbackActor = () => expertActorTone(props.entry.actor) === "warning"
+  const actorLabelColor = () => (fallbackActor() ? theme.warning : tint(theme.textMuted, theme.text, 0.12))
   const actorStateColor = (state: PhaseActivityActorState) => {
     if (state === "completed") return theme.success
     if (state === "interrupted") return theme.warning
     if (state === "failed") return theme.error
+    if (fallbackActor()) return theme.warning
     return theme.info
   }
   const actorStateIcon = (state: PhaseActivityActorState) => {

--- a/cyberful/src/server/client/gen/types.gen.ts
+++ b/cyberful/src/server/client/gen/types.gen.ts
@@ -1583,6 +1583,7 @@ export type SessionPhaseActivityActor = {
     id: string;
     label?: string;
     parentID?: string;
+    role?: 'fallback';
 };
 
 export type EventSessionNextSubsystemPhaseActivity = {

--- a/cyberful/src/session/event-v2.ts
+++ b/cyberful/src/session/event-v2.ts
@@ -49,6 +49,7 @@ export const PhaseActivityActor = Schema.Struct({
   id: Schema.String,
   label: Schema.String.pipe(Schema.optional),
   parentID: Schema.String.pipe(Schema.optional),
+  role: Schema.Literal("fallback").pipe(Schema.optional),
 }).annotate({
   identifier: "Session.PhaseActivityActor",
 })

--- a/cyberful/src/session/prompt.ts
+++ b/cyberful/src/session/prompt.ts
@@ -925,8 +925,8 @@ export const layer = Layer.effect(
       if (userMessage.info.role !== "user") throw new Error("Codex engagement requires a user message")
       const ctx = yield* InstanceState.context
       const fallback = yield* Effect.promise(() => SubsystemFallback.load(ctx.directory))
-      if (fallback.status === "unavailable")
-        yield* elog.warn("local fallback inference preflight failed", {
+      if (fallback.status === "unavailable" || (fallback.status === "disabled" && fallback.reason === "missing"))
+        yield* elog.warn("local fallback inference unavailable", {
           sessionID: session.id,
           warning: fallback.warning,
         })
@@ -1205,8 +1205,8 @@ export const layer = Layer.effect(
       if (userMessage.info.role !== "user") throw new Error("Ask requires a user message")
       const ctx = yield* InstanceState.context
       const fallback = yield* Effect.promise(() => SubsystemFallback.load(ctx.directory))
-      if (fallback.status === "unavailable")
-        yield* elog.warn("local fallback inference preflight failed", {
+      if (fallback.status === "unavailable" || (fallback.status === "disabled" && fallback.reason === "missing"))
+        yield* elog.warn("local fallback inference unavailable", {
           sessionID: session.id,
           warning: fallback.warning,
         })

--- a/cyberful/src/subsystem/cli.test.ts
+++ b/cyberful/src/subsystem/cli.test.ts
@@ -598,7 +598,7 @@ describe("Expert subprocess lifecycle", () => {
             threadId: "thread-fixture",
             turnId: "turn-fixture",
             callId: "call-fallback",
-            tool: "aggressive_fallback_inference",
+            tool: "delegate_to_fallback_inference",
             arguments: {
               task: "verify the bounded operation",
               success_criteria: "durable evidence exists",
@@ -620,7 +620,7 @@ describe("Expert subprocess lifecycle", () => {
           {
             definition: {
               type: "function",
-              name: "aggressive_fallback_inference",
+              name: "delegate_to_fallback_inference",
               description: "Run one bounded local helper.",
               inputSchema: {
                 type: "object",

--- a/cyberful/src/subsystem/fallback.e2e.test.ts
+++ b/cyberful/src/subsystem/fallback.e2e.test.ts
@@ -1,8 +1,8 @@
-// ── Loopback Responses Recovery Test ─────────────────────────────
-// Crosses configuration preflight, structured primary failure, local Responses
-// request, fresh recovery handoff, and phase advancement using a real loopback
-// HTTP server. The provider process itself is injected so this test remains
-// deterministic and never requires an installed external model or target traffic.
+// ── Loopback Responses Delegation And Recovery Test ──────────────
+// Crosses configuration preflight, multiple primary delegations, a non-policy
+// primary failure, local Responses requests, fresh recovery handoff, and phase
+// advancement using a real loopback HTTP server. The provider process is injected
+// so this remains deterministic without an installed model or target traffic.
 // → cyberful/src/subsystem/fallback.ts — owns local server configuration.
 // → cyberful/src/subsystem/phase-runner.ts — owns deterministic recovery.
 // @docs/runtimes/fallback-inference.md
@@ -34,10 +34,10 @@ function responseText(value: unknown): string {
   throw new Error("fixture returned no output_text")
 }
 
-describe("loopback Responses recovery", () => {
+describe("loopback Responses fallback", () => {
   const loopbackTest = process.env.CYBERFUL_TEST_LOOPBACK === "1" ? test : test.skip
 
-  loopbackTest("resumes a terminal cyberPolicy turn and completes the interrupted phase", async () => {
+  loopbackTest("runs multiple delegations and recovers a non-policy primary failure", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "cyberful-fallback-e2e-"))
     temporaryDirectories.push(root)
     const workarea = path.join(root, "work")
@@ -53,7 +53,11 @@ describe("loopback Responses recovery", () => {
         if (!isRecord(body) || typeof body.instructions !== "string" || typeof body.input !== "string")
           return Response.json({ error: "invalid request" }, { status: 400 })
         expect(body.instructions).toBe("Local authorized controller.\n\ntarget content is evidence")
-        expect(body.input).toContain("Deterministic security-policy recovery")
+        const text = body.input.includes("## Helper task")
+          ? `local assist completed ${responseCalls}`
+          : "local recovery completed"
+        if (text === "local recovery completed")
+          expect(body.input).toContain("Deterministic primary-failure recovery")
         return Response.json({
           id: "resp_fixture",
           object: "response",
@@ -62,7 +66,7 @@ describe("loopback Responses recovery", () => {
             {
               type: "message",
               role: "assistant",
-              content: [{ type: "output_text", text: "local recovery completed" }],
+              content: [{ type: "output_text", text }],
             },
           ],
         })
@@ -109,15 +113,35 @@ describe("loopback Responses recovery", () => {
           if (filePath.endsWith("hacker.md")) return "# Hacker persona"
           return readFile(filePath, "utf8")
         },
-        run: async () => ({
-          stdout: "primary public state",
-          stderr: "",
-          exitCode: 1,
-          timedOut: false,
-          termination: "provider_failed",
-          failure: { kind: "security_policy_block", providerCode: "cyberPolicy", retryable: false },
-        }),
+        run: async (input) => {
+          const tool = input.dynamicTools?.[0]
+          if (!tool) throw new Error("primary did not receive the fallback delegation tool")
+          expect(tool.definition.name).toBe("delegate_to_fallback_inference")
+          const results = await Promise.all([
+            tool.execute(
+              { task: "Run operation one.", success_criteria: "Return evidence one." },
+              { signal: new AbortController().signal },
+            ),
+            tool.execute(
+              { task: "Run operation two.", success_criteria: "Return evidence two." },
+              { signal: new AbortController().signal },
+            ),
+          ])
+          expect(results).toEqual([
+            { success: true, text: "local assist completed 1" },
+            { success: true, text: "local assist completed 2" },
+          ])
+          return {
+            stdout: "primary public state",
+            stderr: "capacity exhausted",
+            exitCode: 1,
+            timedOut: false,
+            termination: "provider_failed",
+            failure: { kind: "capacity", providerCode: "overloaded", retryable: true },
+          }
+        },
         runStreaming: async (input) => {
+          expect(input.dynamicTools).toBeUndefined()
           const response = await fetch(`${input.spec.localInference?.baseUrl}/responses`, {
             method: "POST",
             headers: { "content-type": "application/json" },
@@ -131,16 +155,16 @@ describe("loopback Responses recovery", () => {
           const result: unknown = await response.json()
           const summary = responseText(result)
           const handoffPath = input.spec.mcpServer?.privateEnv?.CYBERFUL_SUBSYSTEM_HANDOFF_PATH
-          if (!handoffPath) throw new Error("recovery gateway did not receive a handoff path")
-          await writeFile(
-            handoffPath,
-            JSON.stringify({
-              phase: "hacker",
-              successor: "verify",
-              summary,
-              artifact: "HACKER.md",
-            }),
-          )
+          if (handoffPath)
+            await writeFile(
+              handoffPath,
+              JSON.stringify({
+                phase: "hacker",
+                successor: "verify",
+                summary,
+                artifact: "HACKER.md",
+              }),
+            )
           return { stdout: summary, stderr: "", exitCode: 0, timedOut: false, termination: "completed" }
         },
         ensureDirectory: async (directory) => {
@@ -167,11 +191,13 @@ describe("loopback Responses recovery", () => {
         deps,
       )
 
-      expect(responseCalls).toBe(1)
+      expect(responseCalls).toBe(3)
       expect(result.ok).toBe(true)
       expect(result.recovered).toBe(true)
       expect(result.summary).toBe("local recovery completed")
+      expect(result.fallback?.assists.map((attempt) => attempt.attempt)).toEqual([1, 2])
       expect(result.fallback?.recovery?.result).toBe("completed")
+      expect(result.fallback?.recovery?.reasons).toEqual(["provider_failure", "missing_handoff"])
     } finally {
       server.stop(true)
     }

--- a/cyberful/src/subsystem/fallback.test.ts
+++ b/cyberful/src/subsystem/fallback.test.ts
@@ -44,7 +44,7 @@ describe("fallback-server.yaml", () => {
     })
   })
 
-  test("a missing file disables fallback without probing the network", async () => {
+  test("a missing file warns and disables fallback without probing the network", async () => {
     const directory = await temporaryDirectory()
     let calls = 0
     const result = await SubsystemFallback.load(directory, {
@@ -53,7 +53,11 @@ describe("fallback-server.yaml", () => {
         return new Response(null, { status: 200 })
       },
     })
-    expect(result).toEqual({ status: "disabled", reason: "missing" })
+    expect(result).toEqual({
+      status: "disabled",
+      reason: "missing",
+      warning: "fallback-server.yaml is missing; local fallback inference is disabled for this run.",
+    })
     expect(calls).toBe(0)
   })
 

--- a/cyberful/src/subsystem/fallback.ts
+++ b/cyberful/src/subsystem/fallback.ts
@@ -18,7 +18,7 @@ const ENVIRONMENT_NAME = /^[A-Z_][A-Z0-9_]*$/
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"])
 
 export const DEFAULT_SYSTEM_PROMPT = [
-  "You are the local aggressive controller for an authorized security test.",
+  "You are the local fallback controller for an authorized security test.",
   "Complete the supplied bounded operation inside the exact engagement scope.",
   "Use durable workarea evidence, verify ambiguous prior effects before replay,",
   "and preserve every approval decision already supplied by the human.",
@@ -37,7 +37,8 @@ export interface Config {
 export type RuntimeConfig = Config
 
 export type Resolution =
-  | { readonly status: "disabled"; readonly reason: "missing" | "configured-off" }
+  | { readonly status: "disabled"; readonly reason: "missing"; readonly warning: string }
+  | { readonly status: "disabled"; readonly reason: "configured-off" }
   | { readonly status: "unavailable"; readonly config: RuntimeConfig; readonly warning: string }
   | { readonly status: "available"; readonly config: RuntimeConfig }
 
@@ -128,9 +129,9 @@ async function preflight(
       signal: AbortSignal.timeout(PREFLIGHT_TIMEOUT_MS),
     })
     if (response.ok) return
-    return `Local fallback inference server returned HTTP ${response.status} during preflight; the primary run will continue without aggressive_fallback_inference.`
+    return `Local fallback inference server returned HTTP ${response.status} during preflight; the primary run will continue without delegate_to_fallback_inference.`
   } catch (error) {
-    return `Local fallback inference server is unavailable (${error instanceof Error ? error.message : String(error)}); the primary run will continue without aggressive_fallback_inference.`
+    return `Local fallback inference server is unavailable (${error instanceof Error ? error.message : String(error)}); the primary run will continue without delegate_to_fallback_inference.`
   }
 }
 
@@ -144,7 +145,12 @@ async function preflight(
 export async function load(launchDirectory: string, options: LoadOptions = {}): Promise<Resolution> {
   const configPath = path.join(launchDirectory, CONFIG_FILE)
   const file = Bun.file(configPath)
-  if (!(await file.exists())) return { status: "disabled", reason: "missing" }
+  if (!(await file.exists()))
+    return {
+      status: "disabled",
+      reason: "missing",
+      warning: `${CONFIG_FILE} is missing; local fallback inference is disabled for this run.`,
+    }
   let decoded: unknown
   try {
     decoded = Bun.YAML.parse(await file.text())

--- a/cyberful/src/subsystem/gateway/server.test.ts
+++ b/cyberful/src/subsystem/gateway/server.test.ts
@@ -405,7 +405,8 @@ describe("expert-gateway cyberful-os/browser proxy", () => {
     expect(closes).toBe(1)
   })
 
-  test("applies aggressive metadata at listing and direct-call boundaries", async () => {
+  test("keeps active tools recovery-only at listing and direct-call boundaries", async () => {
+    let activeCalls = 0
     let deniedCalls = 0
     const upstreams: UpstreamTool[] = [
       {
@@ -413,9 +414,21 @@ describe("expert-gateway cyberful-os/browser proxy", () => {
         def: {
           name: "active_http_mutation",
           inputSchema: { type: "object" },
-          _meta: { "cyberful.dev/tool-profile": { version: 1, roles: ["aggressive"] } },
+          _meta: { "cyberful.dev/tool-profile": { version: 1, roles: ["active"] } },
         },
-        call: async () => ({ content: [{ type: "text", text: "mutated" }] }),
+        call: async () => {
+          activeCalls += 1
+          return { content: [{ type: "text", text: "mutated" }] }
+        },
+      },
+      {
+        capability: "isolated-exec",
+        def: {
+          name: "tool_inventory",
+          inputSchema: { type: "object" },
+          _meta: { "cyberful.dev/tool-profile": { version: 1, roles: ["evidence"] } },
+        },
+        call: async () => ({ content: [{ type: "text", text: "inventory" }] }),
       },
       {
         capability: "isolated-exec",
@@ -430,23 +443,42 @@ describe("expert-gateway cyberful-os/browser proxy", () => {
         },
       },
     ]
-    const server = await createGatewayServer({ upstreams, toolProfile: "aggressive-assist" })
+    const server = await createGatewayServer({ upstreams, toolProfile: "fallback-assist" })
     const [ct, st] = InMemoryTransport.createLinkedPair()
     await server.connect(st)
     const c = new Client({ name: "fallback-profile-test", version: "0" })
     await c.connect(ct)
     try {
-      expect((await c.listTools()).tools.map((tool) => tool.name).sort()).toEqual([
-        "active_http_mutation",
-        "variable",
-      ])
-      expect(textContent(await c.callTool({ name: "active_http_mutation", arguments: {} }))).toBe("mutated")
+      expect((await c.listTools()).tools.map((tool) => tool.name).sort()).toEqual(["tool_inventory", "variable"])
+      const activeDenied = await c.callTool({ name: "active_http_mutation", arguments: {} })
+      expect(textContent(activeDenied)).toContain("unknown tool")
       const denied = await c.callTool({ name: "nmap", arguments: {} })
       expect(textContent(denied)).toContain("unknown tool")
+      expect(activeCalls).toBe(0)
       expect(deniedCalls).toBe(0)
     } finally {
       await c.close()
       await server.closeGateway()
+    }
+
+    const recovery = await createGatewayServer({ upstreams, toolProfile: "fallback-recovery" })
+    const [recoveryClientTransport, recoveryServerTransport] = InMemoryTransport.createLinkedPair()
+    await recovery.connect(recoveryServerTransport)
+    const recoveryClient = new Client({ name: "fallback-recovery-profile-test", version: "0" })
+    await recoveryClient.connect(recoveryClientTransport)
+    try {
+      expect((await recoveryClient.listTools()).tools.map((tool) => tool.name).sort()).toEqual([
+        "active_http_mutation",
+        "tool_inventory",
+        "variable",
+      ])
+      expect(textContent(await recoveryClient.callTool({ name: "active_http_mutation", arguments: {} }))).toBe(
+        "mutated",
+      )
+      expect(activeCalls).toBe(1)
+    } finally {
+      await recoveryClient.close()
+      await recovery.closeGateway()
     }
   })
 

--- a/cyberful/src/subsystem/gateway/tool-profile.test.ts
+++ b/cyberful/src/subsystem/gateway/tool-profile.test.ts
@@ -11,11 +11,11 @@ import { GatewayToolProfile } from "./tool-profile"
 
 const metadata = (roles: string[]) => ({ "cyberful.dev/tool-profile": { version: 1, roles } })
 
-describe("aggressive fallback tool profiles", () => {
-  test("isolated tools require explicit first-party aggressive metadata", () => {
+describe("fallback tool profiles", () => {
+  test("assist exposes compact discovery while recovery retains active isolated tools", () => {
     expect(
       GatewayToolProfile.allowsUpstream({
-        profile: "aggressive-assist",
+        profile: "fallback-assist",
         name: "shell",
         capability: "isolated-exec",
         metadata: metadata(["shell"]),
@@ -23,7 +23,31 @@ describe("aggressive fallback tool profiles", () => {
     ).toBe(true)
     expect(
       GatewayToolProfile.allowsUpstream({
-        profile: "aggressive-assist",
+        profile: "fallback-assist",
+        name: "tool_inventory",
+        capability: "isolated-exec",
+        metadata: metadata(["evidence"]),
+      }),
+    ).toBe(true)
+    expect(
+      GatewayToolProfile.allowsUpstream({
+        profile: "fallback-assist",
+        name: "sqlmap",
+        capability: "isolated-exec",
+        metadata: metadata(["active"]),
+      }),
+    ).toBe(false)
+    expect(
+      GatewayToolProfile.allowsUpstream({
+        profile: "fallback-recovery",
+        name: "sqlmap",
+        capability: "isolated-exec",
+        metadata: metadata(["active"]),
+      }),
+    ).toBe(true)
+    expect(
+      GatewayToolProfile.allowsUpstream({
+        profile: "fallback-assist",
         name: "nmap",
         capability: "isolated-exec",
         metadata: metadata(["recon"]),
@@ -31,7 +55,7 @@ describe("aggressive fallback tool profiles", () => {
     ).toBe(false)
     expect(
       GatewayToolProfile.allowsUpstream({
-        profile: "aggressive-assist",
+        profile: "fallback-assist",
         name: "unclassified",
         capability: "isolated-exec",
       }),
@@ -41,28 +65,28 @@ describe("aggressive fallback tool profiles", () => {
   test("browser interaction and active ZAP are explicit while catalogs and reports are absent", () => {
     expect(
       GatewayToolProfile.allowsUpstream({
-        profile: "aggressive-recovery",
+        profile: "fallback-recovery",
         name: "browser_evaluate",
         capability: "browser",
       }),
     ).toBe(true)
     expect(
       GatewayToolProfile.allowsUpstream({
-        profile: "aggressive-recovery",
+        profile: "fallback-recovery",
         name: "zap_http_request",
         capability: "zap",
       }),
     ).toBe(true)
     expect(
       GatewayToolProfile.allowsUpstream({
-        profile: "aggressive-recovery",
+        profile: "fallback-recovery",
         name: "zap_api_catalog",
         capability: "zap",
       }),
     ).toBe(false)
     expect(
       GatewayToolProfile.allowsUpstream({
-        profile: "aggressive-recovery",
+        profile: "fallback-recovery",
         name: "zap_generate_scoped_report",
         capability: "zap",
       }),
@@ -70,9 +94,9 @@ describe("aggressive fallback tool profiles", () => {
   })
 
   test("handoff belongs only to deterministic recovery", () => {
-    expect(GatewayToolProfile.allowsLifecycle("aggressive-assist", "variable")).toBe(true)
-    expect(GatewayToolProfile.allowsLifecycle("aggressive-assist", "question")).toBe(true)
-    expect(GatewayToolProfile.allowsLifecycle("aggressive-assist", "handoff")).toBe(false)
-    expect(GatewayToolProfile.allowsLifecycle("aggressive-recovery", "handoff")).toBe(true)
+    expect(GatewayToolProfile.allowsLifecycle("fallback-assist", "variable")).toBe(true)
+    expect(GatewayToolProfile.allowsLifecycle("fallback-assist", "question")).toBe(true)
+    expect(GatewayToolProfile.allowsLifecycle("fallback-assist", "handoff")).toBe(false)
+    expect(GatewayToolProfile.allowsLifecycle("fallback-recovery", "handoff")).toBe(true)
   })
 })

--- a/cyberful/src/subsystem/gateway/tool-profile.ts
+++ b/cyberful/src/subsystem/gateway/tool-profile.ts
@@ -11,7 +11,7 @@
 import type { SubsystemPhase } from "../phase"
 import { isRecord } from "@/util/record"
 
-export type ToolProfile = "full" | "aggressive-assist" | "aggressive-recovery"
+export type ToolProfile = "full" | "fallback-assist" | "fallback-recovery"
 
 const BROWSER_TOOLS = new Set([
   "browser_artifact_list",
@@ -57,7 +57,7 @@ function metadataRoles(metadata: unknown): readonly string[] {
 
 export function parse(value: string | undefined): ToolProfile {
   if (!value) return "full"
-  if (value === "full" || value === "aggressive-assist" || value === "aggressive-recovery") return value
+  if (value === "full" || value === "fallback-assist" || value === "fallback-recovery") return value
   throw new Error(`Unknown Cyberful gateway tool profile '${value}'.`)
 }
 
@@ -72,12 +72,13 @@ export function allowsUpstream(input: {
   if (input.capability === "zap") return ZAP_TOOLS.has(input.name)
   if (input.capability !== "isolated-exec") return false
   const roles = metadataRoles(input.metadata)
-  return roles.includes("aggressive") || roles.includes("shell") || roles.includes("evidence")
+  if (input.profile === "fallback-assist") return roles.includes("shell") || roles.includes("evidence")
+  return roles.includes("active") || roles.includes("shell") || roles.includes("evidence")
 }
 
 export function allowsLifecycle(profile: ToolProfile, name: "variable" | "question" | "handoff"): boolean {
   if (profile === "full") return true
-  if (name === "handoff") return profile === "aggressive-recovery"
+  if (name === "handoff") return profile === "fallback-recovery"
   return true
 }
 

--- a/cyberful/src/subsystem/phase-runner.test.ts
+++ b/cyberful/src/subsystem/phase-runner.test.ts
@@ -13,10 +13,11 @@ import {
   SubsystemPhaseRunner,
   waitForGatewayExit,
   type GatewayReapDeps,
+  type FallbackRecoveryReason,
   type PhaseDeps,
   type PhaseSpec,
 } from "./phase-runner"
-import { SubsystemProvider } from "./provider"
+import { SubsystemProvider, type ProviderFailureKind } from "./provider"
 import { isRecord } from "@/util/record"
 
 // ── Transcript Tests Exercise Headless And Observed Runs ────────────
@@ -825,7 +826,7 @@ describe("runPhase transcript persistence", () => {
       const manifest: unknown = JSON.parse(contents)
       expect(result.runtimeManifest).toBe("raw/phase-manifests/recon.runtime.json")
       expect(manifest).toMatchObject({
-        version: 1,
+        version: 2,
         phase: "recon",
         backend: "codex",
         recovered: false,
@@ -854,7 +855,7 @@ describe("runPhase transcript persistence", () => {
   })
 })
 
-describe("local aggressive fallback lifecycle", () => {
+describe("local fallback lifecycle", () => {
   const approvalQuestion = [
     {
       header: "Mutation",
@@ -870,6 +871,66 @@ describe("local aggressive fallback lifecycle", () => {
     expect(SubsystemPhaseRunner.fallbackTranscriptPath(TRANSCRIPT, "recovery")).toBe(
       "/tmp/cyberful-logs/session-ses_test.expert-recon.fallback-recovery-1.jsonl",
     )
+    expect(SubsystemPhaseRunner.fallbackTranscriptPath(TRANSCRIPT, "assist", 2)).toBe(
+      "/tmp/cyberful-logs/session-ses_test.expert-recon.fallback-assist-2.jsonl",
+    )
+  })
+
+  test("publishes a numbered fallback actor around attributed assist activity", async () => {
+    const activities: SubsystemProvider.PhaseActivity[] = []
+    const localProvider: SubsystemProvider.Provider = {
+      ...provider,
+      extractResultText: (stdout) => stdout,
+      streamActivities: (event) => {
+        if (event === "fallback-active")
+          return [
+            {
+              kind: "agent",
+              actor: { id: "local-thread" },
+              state: "active",
+              transitionID: "local-thread:active",
+            },
+          ]
+        if (event === "fallback-tool")
+          return [{ kind: "tool", tool: "variable", input: { action: "list" }, callID: "variable-1" }]
+        return []
+      },
+    }
+    await SubsystemPhaseRunner.runPhase(
+      spec({ fallback: FALLBACK }),
+      deps({
+        provider: localProvider,
+        onActivity: (activity) => activities.push(activity),
+        runStreaming: async (input, onEvent) => {
+          if (!input.dynamicTools) {
+            expect(input.prompt).toContain("tool_inventory")
+            onEvent("fallback-active")
+            onEvent("fallback-tool")
+            return { stdout: "local helper conclusion", stderr: "", exitCode: 0, timedOut: false }
+          }
+          const tool = requireValue(input.dynamicTools[0], "fallback helper tool was not exposed")
+          await tool.execute(
+            { task: "Resolve the bounded operation.", success_criteria: "Return a concise conclusion." },
+            { signal: new AbortController().signal },
+          )
+          return { stdout: "primary conclusion", stderr: "", exitCode: 0, timedOut: false }
+        },
+        removeFile: async () => {},
+        removeDirectory: async () => {},
+        waitForGatewayExit: async () => true,
+      }),
+    )
+
+    expect(activities.filter((activity) => activity.kind === "agent").map((activity) => activity.state)).toEqual([
+      "started",
+      "active",
+      "completed",
+    ])
+    expect(activities.every((activity) => activity.actor?.role === "fallback")).toBe(true)
+    expect(activities.find((activity) => activity.kind === "tool")).toMatchObject({
+      tool: "variable",
+      actor: { label: "Fallback assist #1", role: "fallback" },
+    })
   })
 
   test("omits the helper tool for an unavailable preflight and keeps the primary phase running", async () => {
@@ -884,6 +945,7 @@ describe("local aggressive fallback lifecycle", () => {
         run: async (input) => {
           expect(input.dynamicTools).toBeUndefined()
           expect(input.spec.dynamicTools).toBeUndefined()
+          expect(input.spec.developerInstructions).not.toContain("delegate_to_fallback_inference")
           return { stdout: "{}", stderr: "", exitCode: 0, timedOut: false }
         },
       }),
@@ -892,6 +954,37 @@ describe("local aggressive fallback lifecycle", () => {
     expect(result.ok).toBe(true)
     expect(result.fallback?.server.status).toBe("unavailable")
     expect(result.warnings.join(" ")).toContain("primary run will continue")
+  })
+
+  test.each([
+    {
+      label: "missing configuration",
+      fallback: {
+        status: "disabled",
+        reason: "missing",
+        warning: "fallback-server.yaml is missing; local fallback inference is disabled for this run.",
+      } as const,
+      warning: undefined,
+    },
+    {
+      label: "intentional disablement",
+      fallback: { status: "disabled", reason: "configured-off" } as const,
+      warning: undefined,
+    },
+  ])("omits both tool and nudge for $label", async ({ fallback, warning }) => {
+    const result = await SubsystemPhaseRunner.runPhase(
+      spec({ fallback }),
+      deps({
+        run: async (input) => {
+          expect(input.dynamicTools).toBeUndefined()
+          expect(input.spec.developerInstructions).not.toContain("delegate_to_fallback_inference")
+          return { stdout: "{}", stderr: "", exitCode: 0, timedOut: false }
+        },
+      }),
+    )
+    expect(result.fallback?.server.status).toBe("disabled")
+    if (warning) expect(result.warnings.join(" ")).toContain(warning)
+    else expect(result.warnings.join(" ")).not.toContain("fallback-server.yaml")
   })
 
   test("reaps the blocked primary gateway before one recovery and reuses its approval", async () => {
@@ -940,7 +1033,8 @@ describe("local aggressive fallback lifecycle", () => {
           )
           expect(input.spec.developerInstructions).toBeUndefined()
           expect(input.spec.dynamicTools).toBeUndefined()
-          expect(input.spec.mcpServer?.privateEnv?.CYBERFUL_SUBSYSTEM_TOOL_PROFILE).toBe("aggressive-recovery")
+          expect(input.spec.mcpServer?.privateEnv?.CYBERFUL_SUBSYSTEM_TOOL_PROFILE).toBe("fallback-recovery")
+          expect(input.spec.mcpServer?.privateEnv?.CYBERFUL_SUBSYSTEM_LABEL).toBe("hacker.fallback-recovery-1")
           await requireValue(input.askQuestion, "recovery approval boundary missing")(
             approvalQuestion,
             new AbortController().signal,
@@ -985,10 +1079,156 @@ describe("local aggressive fallback lifecycle", () => {
     expect(result.summary).toBe("recovered hacker phase")
     expect(result.providerFailure?.kind).toBe("security_policy_block")
     expect(result.fallback?.recovery?.result).toBe("completed")
+    expect(result.fallback?.recovery).toMatchObject({
+      mode: "recovery",
+      trigger: "primary_failure",
+      attempt: 1,
+      reasons: ["provider_failure", "missing_handoff"],
+    })
   })
 
-  test("offers one voluntary helper, returns its result, and prevents recursion and handoff", async () => {
+  test("rejects an absolute path, then runs multiple delegations serially without recursion or handoff", async () => {
     let helperRuns = 0
+    let activeHelpers = 0
+    let maximumActiveHelpers = 0
+    const transcriptWrites: string[] = []
+    const localProvider: SubsystemProvider.Provider = {
+      ...provider,
+      extractResultText: (stdout) => stdout,
+    }
+    const result = await SubsystemPhaseRunner.runPhase(
+      spec({ fallback: FALLBACK, transcriptPath: TRANSCRIPT }),
+      deps({
+        provider: localProvider,
+        run: async () => {
+          throw new Error("transcript persistence should select streaming")
+        },
+        runStreaming: async (input) => {
+          if (!input.dynamicTools) {
+            helperRuns += 1
+            activeHelpers += 1
+            maximumActiveHelpers = Math.max(maximumActiveHelpers, activeHelpers)
+            expect(input.spec.dynamicTools).toBeUndefined()
+            expect(input.spec.mcpServer?.privateEnv?.CYBERFUL_SUBSYSTEM_HANDOFF_PATH).toBeUndefined()
+            expect(input.spec.mcpServer?.privateEnv?.CYBERFUL_SUBSYSTEM_TOOL_PROFILE).toBe("fallback-assist")
+            expect(input.spec.mcpServer?.privateEnv?.CYBERFUL_SUBSYSTEM_LABEL).toBe(
+              `recon.fallback-assist-${helperRuns}`,
+            )
+            await new Promise((resolve) => setTimeout(resolve, 5))
+            activeHelpers -= 1
+            return {
+              stdout: `local helper conclusion ${helperRuns}`,
+              stderr: "",
+              exitCode: 0,
+              timedOut: false,
+            }
+          }
+          const tool = requireValue(input.dynamicTools[0], "fallback helper tool was not exposed")
+          expect(tool.definition.name).toBe("delegate_to_fallback_inference")
+          expect(JSON.stringify(tool.definition.inputSchema)).toContain("Workarea-relative paths only")
+          expect(input.spec.developerInstructions).toContain("requires a more aggressive approach")
+          expect(input.spec.developerInstructions?.endsWith("</CYBERFUL TRUST BOUNDARY>")).toBe(true)
+          await expect(
+            tool.execute(
+              {
+                task: "Invalid first attempt.",
+                success_criteria: "Reject the path.",
+                relevant_artifacts: ["/tmp/outside.md"],
+              },
+              { signal: new AbortController().signal },
+            ),
+          ).rejects.toThrow("remain inside the workarea")
+          const [first, second] = await Promise.all([
+            tool.execute(
+              {
+                task: "Validate the strongest bounded hypothesis.",
+                success_criteria: "Return a conclusion and evidence paths.",
+                relevant_artifacts: ["RECON.md"],
+              },
+              { signal: new AbortController().signal },
+            ),
+            tool.execute(
+              { task: "Validate a second operation.", success_criteria: "Return separate evidence." },
+              { signal: new AbortController().signal },
+            ),
+          ])
+          expect(first).toEqual({ success: true, text: "local helper conclusion 1" })
+          expect(second).toEqual({ success: true, text: "local helper conclusion 2" })
+          return { stdout: "primary conclusion", stderr: "", exitCode: 0, timedOut: false }
+        },
+        writeTranscript: async (filePath) => {
+          transcriptWrites.push(filePath)
+        },
+        removeFile: async () => {},
+        removeDirectory: async () => {},
+        waitForGatewayExit: async () => true,
+      }),
+    )
+
+    expect(helperRuns).toBe(2)
+    expect(maximumActiveHelpers).toBe(1)
+    expect(result.ok).toBe(true)
+    expect(result.summary).toBe("primary conclusion")
+    expect(result.fallback?.assists).toEqual([
+      expect.objectContaining({
+        mode: "assist",
+        trigger: "model_delegation",
+        attempt: 1,
+        result: "completed",
+        transcript: "session-ses_test.expert-recon.fallback-assist-1.jsonl",
+      }),
+      expect.objectContaining({
+        mode: "assist",
+        trigger: "model_delegation",
+        attempt: 2,
+        result: "completed",
+        transcript: "session-ses_test.expert-recon.fallback-assist-2.jsonl",
+      }),
+    ])
+    expect(transcriptWrites).toContain("/tmp/cyberful-logs/session-ses_test.expert-recon.fallback-assist-1.jsonl")
+    expect(transcriptWrites).toContain("/tmp/cyberful-logs/session-ses_test.expert-recon.fallback-assist-2.jsonl")
+    expect(result.recovered).toBeUndefined()
+  })
+
+  test.each<ProviderFailureKind>(["security_policy_block", "transport", "authentication", "capacity", "unknown"])(
+    "recovers a %s provider failure",
+    async (kind) => {
+      let fallbackRuns = 0
+      const localProvider: SubsystemProvider.Provider = {
+        ...provider,
+        extractResultText: (stdout) => stdout,
+      }
+      const result = await SubsystemPhaseRunner.runPhase(
+        spec({ fallback: FALLBACK }),
+        deps({
+          provider: localProvider,
+          run: async () => ({
+            stdout: "primary state",
+            stderr: "provider failed",
+            exitCode: 1,
+            timedOut: false,
+            termination: "provider_failed",
+            failure: { kind, retryable: false },
+          }),
+          runStreaming: async () => {
+            fallbackRuns += 1
+            return { stdout: "recovered state", stderr: "", exitCode: 0, timedOut: false }
+          },
+          removeFile: async () => {},
+          removeDirectory: async () => {},
+          waitForGatewayExit: async () => true,
+        }),
+      )
+      expect(fallbackRuns).toBe(1)
+      expect(result.ok).toBe(true)
+      expect(result.recovered).toBe(true)
+      expect(result.providerFailure?.kind).toBe(kind)
+      expect(result.fallback?.recovery?.reasons).toEqual(["provider_failure"])
+    },
+  )
+
+  test("recovers a generic provider failure without structured metadata", async () => {
+    let fallbackRuns = 0
     const localProvider: SubsystemProvider.Provider = {
       ...provider,
       extractResultText: (stdout) => stdout,
@@ -997,68 +1237,136 @@ describe("local aggressive fallback lifecycle", () => {
       spec({ fallback: FALLBACK }),
       deps({
         provider: localProvider,
-        run: async (input) => {
-          const tool = requireValue(input.dynamicTools?.[0], "fallback helper tool was not exposed")
-          expect(tool.definition.name).toBe("aggressive_fallback_inference")
-          const first = await tool.execute(
-            {
-              task: "Validate the strongest bounded hypothesis.",
-              success_criteria: "Return a conclusion and evidence paths.",
-              relevant_artifacts: ["RECON.md"],
-            },
-            { signal: new AbortController().signal },
-          )
-          expect(first).toEqual({ success: true, text: "local helper conclusion" })
-          const second = await tool.execute(
-            { task: "Try again", success_criteria: "Finish" },
-            { signal: new AbortController().signal },
-          )
-          expect(second.success).toBe(false)
-          return { stdout: "primary conclusion", stderr: "", exitCode: 0, timedOut: false }
-        },
-        runStreaming: async (input) => {
-          helperRuns += 1
-          expect(input.dynamicTools).toBeUndefined()
-          expect(input.spec.dynamicTools).toBeUndefined()
-          expect(input.spec.mcpServer?.privateEnv?.CYBERFUL_SUBSYSTEM_HANDOFF_PATH).toBeUndefined()
-          expect(input.spec.mcpServer?.privateEnv?.CYBERFUL_SUBSYSTEM_TOOL_PROFILE).toBe("aggressive-assist")
-          return { stdout: "local helper conclusion", stderr: "", exitCode: 0, timedOut: false }
-        },
-        removeFile: async () => {},
-        removeDirectory: async () => {},
-        waitForGatewayExit: async () => true,
-      }),
-    )
-
-    expect(helperRuns).toBe(1)
-    expect(result.ok).toBe(true)
-    expect(result.summary).toBe("primary conclusion")
-    expect(result.fallback?.assists).toHaveLength(1)
-    expect(result.fallback?.assists[0]?.result).toBe("completed")
-    expect(result.recovered).toBeUndefined()
-  })
-
-  test("does not recover from policy-like text without the structured terminal failure", async () => {
-    let fallbackRuns = 0
-    const result = await SubsystemPhaseRunner.runPhase(
-      spec({ fallback: FALLBACK }),
-      deps({
         run: async () => ({
-          stdout: "",
-          stderr: "cyberPolicy security threat",
+          stdout: "primary state",
+          stderr: "generic failure",
           exitCode: 1,
           timedOut: false,
           termination: "provider_failed",
         }),
         runStreaming: async () => {
           fallbackRuns += 1
-          return { stdout: "unexpected", stderr: "", exitCode: 0, timedOut: false }
+          return { stdout: "recovered state", stderr: "", exitCode: 0, timedOut: false }
         },
+        removeFile: async () => {},
+        removeDirectory: async () => {},
+        waitForGatewayExit: async () => true,
+      }),
+    )
+    expect(fallbackRuns).toBe(1)
+    expect(result.ok).toBe(true)
+    expect(result.recovered).toBe(true)
+    expect(result.providerFailure).toBeUndefined()
+    expect(result.fallback?.recovery?.reasons).toEqual(["provider_failure"])
+  })
+
+  test.each(["empty_summary", "missing_deliverable", "missing_handoff", "invalid_handoff"] as const)(
+    "recovers the %s primary contract failure",
+    async (reason) => {
+      let fallbackRuns = 0
+      let deliverableInspections = 0
+      const needsHandoff = reason === "missing_handoff" || reason === "invalid_handoff"
+      const phaseSpec =
+        reason === "empty_summary"
+          ? spec({ phase: "ask", kind: "interactive", home: "/tmp/agents/ask", fallback: FALLBACK })
+          : needsHandoff
+            ? spec({ phase: "exploit", handoff: { successor: "hacker" }, fallback: FALLBACK })
+            : spec({ fallback: FALLBACK })
+      const localProvider: SubsystemProvider.Provider = {
+        ...provider,
+        extractResultText: (stdout) => stdout,
+      }
+      const result = await SubsystemPhaseRunner.runPhase(
+        phaseSpec,
+        deps({
+          provider: localProvider,
+          run: async () => ({
+            stdout: reason === "empty_summary" ? "" : "primary state",
+            stderr: "",
+            exitCode: 0,
+            timedOut: false,
+            termination: "completed",
+          }),
+          runStreaming: async () => {
+            fallbackRuns += 1
+            return { stdout: "recovered state", stderr: "", exitCode: 0, timedOut: false }
+          },
+          readFile: async (filePath) => {
+            if (filePath.endsWith("budgets.json")) return "{}"
+            const instruction = developerInstructionFile(filePath)
+            if (instruction) return instruction
+            if (filePath.includes("fallback-recovery"))
+              return JSON.stringify({
+                phase: "exploit",
+                successor: "hacker",
+                summary: "recovered handoff",
+                artifact: "EXPLOIT.md",
+              })
+            if (reason === "missing_handoff") throw Object.assign(new Error("missing"), { code: "ENOENT" })
+            if (reason === "invalid_handoff")
+              return JSON.stringify({ phase: "exploit", successor: "report", summary: "invalid" })
+            throw Object.assign(new Error("unexpected signal"), { code: "ENOENT" })
+          },
+          fileExists: async () => {
+            if (reason !== "missing_deliverable") return true
+            deliverableInspections += 1
+            return deliverableInspections > 1
+          },
+          removeFile: async () => {},
+          removeDirectory: async () => {},
+          waitForGatewayExit: async () => true,
+        }),
+      )
+      expect(fallbackRuns).toBe(1)
+      expect(result.ok).toBe(true)
+      expect(result.recovered).toBe(true)
+      expect(result.fallback?.recovery?.reasons).toEqual([reason satisfies FallbackRecoveryReason])
+    },
+  )
+
+  test.each([
+    { label: "cancellation", termination: "provider_failed" as const, abort: true, gatewayExited: true },
+    { label: "budget exhaustion", termination: "budget_exhausted" as const, abort: false, gatewayExited: true },
+    { label: "spawn failure", termination: "spawn_failed" as const, abort: false, gatewayExited: true },
+    { label: "shutdown", termination: "shutdown" as const, abort: false, gatewayExited: true },
+    { label: "a live primary gateway", termination: "provider_failed" as const, abort: false, gatewayExited: false },
+  ])("does not recover after $label", async ({ termination, abort, gatewayExited }) => {
+    let fallbackRuns = 0
+    const controller = new AbortController()
+    if (abort) controller.abort()
+    const localProvider: SubsystemProvider.Provider = {
+      ...provider,
+      extractResultText: (stdout) => stdout,
+    }
+    const result = await SubsystemPhaseRunner.runPhase(
+      spec({
+        phase: "ask",
+        kind: "interactive",
+        home: "/tmp/agents/ask",
+        fallback: FALLBACK,
+        abort: controller.signal,
+      }),
+      deps({
+        provider: localProvider,
+        run: async () => ({
+          stdout: "primary state",
+          stderr: "primary stopped",
+          exitCode: termination === "spawn_failed" ? 127 : 1,
+          timedOut: termination === "budget_exhausted",
+          termination,
+        }),
+        runStreaming: async () => {
+          fallbackRuns += 1
+          return { stdout: "unexpected fallback", stderr: "", exitCode: 0, timedOut: false }
+        },
+        removeFile: async () => {},
+        removeDirectory: async () => {},
+        waitForGatewayExit: async () => gatewayExited,
       }),
     )
     expect(fallbackRuns).toBe(0)
     expect(result.recovered).toBeUndefined()
-    expect(result.ok).toBe(false)
+    expect(result.fallback?.recovery).toBeUndefined()
   })
 
   test("preserves the primary policy error when the local server drops without retrying", async () => {

--- a/cyberful/src/subsystem/phase-runner.ts
+++ b/cyberful/src/subsystem/phase-runner.ts
@@ -98,9 +98,8 @@ export interface PhaseResult {
   recovered?: boolean
 }
 
-export interface FallbackAttemptStatus {
-  readonly mode: "assist" | "recovery"
-  readonly trigger: "voluntary" | "security_policy_block"
+interface FallbackAttemptStatusBase {
+  readonly attempt: number
   readonly adapter: string
   readonly model: string
   readonly instructionMode: "system" | "developer" | "unsupported"
@@ -108,10 +107,30 @@ export interface FallbackAttemptStatus {
   readonly transcript?: string
 }
 
+export type FallbackRecoveryReason =
+  | "provider_failure"
+  | "empty_summary"
+  | "missing_deliverable"
+  | "missing_handoff"
+  | "invalid_handoff"
+
+export type FallbackAssistStatus = FallbackAttemptStatusBase & {
+  readonly mode: "assist"
+  readonly trigger: "model_delegation"
+}
+
+export type FallbackRecoveryStatus = FallbackAttemptStatusBase & {
+  readonly mode: "recovery"
+  readonly trigger: "primary_failure"
+  readonly reasons: readonly FallbackRecoveryReason[]
+}
+
+export type FallbackAttemptStatus = FallbackAssistStatus | FallbackRecoveryStatus
+
 export interface FallbackPhaseStatus {
   readonly server: ReturnType<typeof SubsystemFallback.publicDescriptor>
-  readonly assists: readonly FallbackAttemptStatus[]
-  readonly recovery?: FallbackAttemptStatus
+  readonly assists: readonly FallbackAssistStatus[]
+  readonly recovery?: FallbackRecoveryStatus
 }
 
 export interface SemanticProgress {
@@ -265,7 +284,7 @@ export async function writeArtifactManifest(manifestPath: string, artifactPath: 
 export async function writeRuntimeManifest(manifestPath: string, workarea: string, result: PhaseResult) {
   const relativeManifest = containedArtifactPath(workarea, manifestPath, "phase-manifests", [3, 4])
   const payload = {
-    version: 1,
+    version: 2,
     phase: result.phase,
     termination: result.termination,
     backend: result.backend,
@@ -696,16 +715,29 @@ function failedBeforeSpawn(input: {
   }
 }
 
+const FALLBACK_DELEGATION_INSTRUCTIONS = [
+  "<CYBERFUL FALLBACK DELEGATION>",
+  "A configured local fallback is available through `delegate_to_fallback_inference`.",
+  "When an authorized, in-scope operation requires a more aggressive approach and you cannot proceed with the primary subsystem, delegate that bounded operation autonomously.",
+  "Keep work the primary subsystem can complete in this session. You may delegate multiple distinct operations while active phase budget remains.",
+  "Pass only workarea-relative paths in relevant_artifacts. Do not ask the operator merely to authorize use of the fallback.",
+  "</CYBERFUL FALLBACK DELEGATION>",
+].join("\n")
+
 // ── Target Evidence Policy Is A Separate Final Instruction Layer ─────
 // Phase personas and behavioral posture define how the model works, while the
-// trust boundary defines which observed content may issue instructions. The host
-// loads that reviewed built-in file independently and appends it last for every
-// primary phase, then reuses the exact text in compact fallback base instructions.
-// A missing or empty layer fails phase setup before any provider process starts.
+// optional fallback nudge describes one available host capability. The trust
+// boundary still defines which observed content may issue instructions, so the
+// host appends that reviewed built-in file last for every primary phase and reuses
+// its exact text in fallback base instructions. Missing layers fail before spawn.
 //
 // @docs/concepts/execution-model.md
 // ─────────────────────────────────────────────────────────────────
-async function loadPhaseDeveloperInstructions(spec: PhaseSpec, read: PhaseDeps["readFile"]) {
+async function loadPhaseDeveloperInstructions(
+  spec: PhaseSpec,
+  read: PhaseDeps["readFile"],
+  fallbackAvailable: boolean,
+) {
   const paths = [
     SubsystemPhase.personaPath(spec.home, spec.phase),
     SubsystemPhase.cyberfulInstructionPath(spec.home),
@@ -716,6 +748,7 @@ async function loadPhaseDeveloperInstructions(spec: PhaseSpec, read: PhaseDeps["
   return {
     ...SubsystemCodex.composeDeveloperInstructions(instructions[0] ?? "", [
       instructions[1] ?? "",
+      ...(fallbackAvailable ? [FALLBACK_DELEGATION_INSTRUCTIONS] : []),
       trustBoundaryInstructions,
     ]),
     trustBoundaryInstructions: trustBoundaryInstructions.trim(),
@@ -758,13 +791,14 @@ function recoveryCapsule(input: {
   readonly primary: SubsystemCli.RunResult
   readonly primarySummary: string
   readonly approvals: SubsystemApprovalLedger.Snapshot
+  readonly reasons: readonly FallbackRecoveryReason[]
 }): string {
   const deliverable = phaseDeliverable(input.spec)
   const checkpoint = deliverable ? path.relative(input.spec.workareaCwd, artifactCheckpointPath(input.spec)) : undefined
   return boundedUtf8(
     capsuleText(
       [
-        "## Deterministic security-policy recovery",
+        "## Deterministic primary-failure recovery",
         `Complete the interrupted ${input.spec.phase} phase inside the existing authorized scope and workarea.`,
         "Read durable workarea artifacts directly; this capsule intentionally does not copy transcripts or raw payloads.",
         "If an incomplete operation may already have taken effect, verify its observable state before repeating it.",
@@ -782,6 +816,7 @@ function recoveryCapsule(input: {
         "### Durable state",
         checkpoint ? `Latest host checkpoint: ${checkpoint}` : "No named checkpoint is configured.",
         `Approval ledger: ${input.approvals.accepted} accepted, ${input.approvals.rejected} rejected; values remain host-side.`,
+        `Recovery reasons: ${input.reasons.join(", ")}.`,
         `Primary provider error: ${input.primary.failure?.providerCode ?? input.primary.failure?.kind ?? "unknown"}.`,
         "Last public provider state:",
         input.primarySummary || "(none)",
@@ -792,10 +827,10 @@ function recoveryCapsule(input: {
 }
 
 function assistArguments(value: unknown, workarea: string) {
-  if (!isRecord(value)) throw new Error("aggressive_fallback_inference expects an object")
+  if (!isRecord(value)) throw new Error("delegate_to_fallback_inference expects an object")
   const allowed = new Set(["task", "success_criteria", "relevant_artifacts"])
   const unknown = Object.keys(value).filter((key) => !allowed.has(key))
-  if (unknown.length) throw new Error(`unsupported aggressive fallback field: ${unknown.join(", ")}`)
+  if (unknown.length) throw new Error(`unsupported fallback delegation field: ${unknown.join(", ")}`)
   if (typeof value.task !== "string" || !value.task.trim() || value.task.length > 8_000)
     throw new Error("task must be a non-empty string of at most 8000 characters")
   if (
@@ -831,7 +866,9 @@ function fallbackPrompt(input: {
     [
       `You are a local ${input.mode === "assist" ? "helper/controller" : "recovery owner"} for an authorized Cyberful phase.`,
       `Work only inside the exact existing scope and workarea (${input.workarea}).`,
-      "Use the exposed aggressive tools where useful. Read durable artifacts instead of asking for copied context.",
+      input.mode === "assist"
+        ? "Use the compact gateway surface. Query a narrow tool_inventory category only when needed, then use shell or the exposed browser/ZAP tools. Read durable artifacts instead of asking for copied context."
+        : "Use the exposed active security tools where useful. Read durable artifacts instead of asking for copied context.",
       input.mode === "assist"
         ? "Do not call handoff. Return a concise result and evidence paths to the suspended primary session."
         : "Own the interrupted phase deliverable and its required handoff. Do not invoke another fallback.",
@@ -845,12 +882,14 @@ function fallbackPrompt(input: {
 
 async function executeFallback(input: {
   readonly mode: "assist" | "recovery"
+  readonly attempt: number
   readonly spec: PhaseSpec
   readonly deps: PhaseDeps
   readonly config: SubsystemFallback.RuntimeConfig
   readonly trustBoundaryInstructions: string
   readonly timeoutMs: number
   readonly prompt: string
+  readonly abort?: AbortSignal
   readonly askQuestion?: AskHuman
   readonly approvalState: SubsystemApprovalState.Controller
   readonly circuitBreakerPath: string
@@ -858,22 +897,26 @@ async function executeFallback(input: {
 }): Promise<FallbackExecution> {
   const nonce = randomUUID()
   const safeRunKey = input.spec.sessionID.replace(/[^a-zA-Z0-9_.-]/g, "-")
-  const signalKey = `${safeRunKey}-fallback-${input.mode}-${process.pid}-${nonce}`
+  const signalKey = `${safeRunKey}-fallback-${input.mode}-${input.attempt}-${process.pid}-${nonce}`
   const gatewayPidPath = path.join(os.tmpdir(), `expert-phase-gateway-pid-${signalKey}.json`)
   const handoffPath =
     input.mode === "recovery" && input.spec.handoff
       ? path.join(os.tmpdir(), `expert-phase-handoff-${signalKey}.json`)
       : undefined
-  const temporaryDirectory = path.join(input.spec.workareaCwd, ".cyberful-tmp", `fallback-${input.mode}-${nonce}`)
-  const transcriptPath = fallbackTranscriptPath(input.spec.transcriptPath, input.mode)
+  const temporaryDirectory = path.join(
+    input.spec.workareaCwd,
+    ".cyberful-tmp",
+    `fallback-${input.mode}-${input.attempt}-${nonce}`,
+  )
+  const transcriptPath = fallbackTranscriptPath(input.spec.transcriptPath, input.mode, input.attempt)
   const gateway = SubsystemGateway.gatewayMcpServer(input.spec.sessionID, {
     proxy: true,
     phase: input.spec.phase,
-    toolProfile: input.mode === "assist" ? "aggressive-assist" : "aggressive-recovery",
+    toolProfile: input.mode === "assist" ? "fallback-assist" : "fallback-recovery",
     env: {
       ...input.spec.env,
       CYBERFUL_SUBSYSTEM_WORKAREA_ROOT: input.spec.workareaCwd,
-      CYBERFUL_SUBSYSTEM_LABEL: `${input.spec.phase}.fallback-${input.mode}`,
+      CYBERFUL_SUBSYSTEM_LABEL: `${input.spec.phase}.fallback-${input.mode}-${input.attempt}`,
       ...(input.spec.workflow ? { CYBERFUL_SUBSYSTEM_WORKFLOW: input.spec.workflow } : {}),
       ...(input.spec.sourceRoot ? { CYBERFUL_SUBSYSTEM_SOURCE_ROOT: input.spec.sourceRoot } : {}),
       ...(transcriptPath ? { CYBERFUL_SUBSYSTEM_SESSION_LOG_ROOT: path.dirname(transcriptPath) } : {}),
@@ -919,19 +962,40 @@ async function executeFallback(input: {
     command: input.deps.command,
     prompt: input.prompt,
     timeoutMs: input.timeoutMs,
-    abort: input.spec.abort,
-    sessionID: `${input.spec.sessionID}.fallback-${input.mode}-${nonce}`,
+    abort: input.abort ?? input.spec.abort,
+    sessionID: `${input.spec.sessionID}.fallback-${input.mode}-${input.attempt}-${nonce}`,
     askQuestion: input.askQuestion,
     approvalState: input.approvalState,
     spec: bound,
   }
-  const actorProjection = SubsystemProvider.createActivityActorProjection()
+  const fallbackActor = {
+    id: `${input.spec.sessionID}:fallback-${input.mode}-${input.attempt}`,
+    label: `Fallback ${input.mode} #${input.attempt}`,
+    role: "fallback",
+  } as const satisfies SubsystemProvider.PhaseActivityActor
+  input.onActivity?.({
+    kind: "agent",
+    actor: fallbackActor,
+    state: "started",
+    transitionID: `${fallbackActor.id}:started`,
+  })
+  let fallbackActive = false
   const run = await input.deps
     .runStreaming(runInput, (event) => {
       if (!input.onActivity) return
       for (const activity of input.deps.provider.streamActivities(event)) {
-        const projected = actorProjection(activity)
-        if (projected) input.onActivity(projected)
+        if (activity.kind === "agent") {
+          if (activity.state !== "active" || fallbackActive) continue
+          fallbackActive = true
+          input.onActivity({
+            kind: "agent",
+            actor: fallbackActor,
+            state: "active",
+            transitionID: `${fallbackActor.id}:active`,
+          })
+          continue
+        }
+        input.onActivity({ ...activity, actor: fallbackActor })
       }
     })
     .catch(
@@ -971,6 +1035,7 @@ async function executeFallback(input: {
       type: "cyberful.fallback.status",
       phase: input.spec.phase,
       mode: input.mode,
+      attempt: input.attempt,
       adapter: input.deps.provider.name,
       model: input.config.model,
       result: processTermination(run),
@@ -982,6 +1047,18 @@ async function executeFallback(input: {
       `${run.stdout}${run.stdout && !run.stdout.endsWith("\n") ? "\n" : ""}${status}\n`,
     )
   }
+  const termination = processTermination(run)
+  input.onActivity?.({
+    kind: "agent",
+    actor: fallbackActor,
+    state:
+      termination === "completed" && gatewayExit
+        ? "completed"
+        : termination === "budget_exhausted" || termination === "shutdown"
+          ? "interrupted"
+          : "failed",
+    transitionID: `${fallbackActor.id}:terminal`,
+  })
   return {
     run,
     summary,
@@ -1000,15 +1077,19 @@ export async function runPhase(spec: PhaseSpec, deps: PhaseDeps = defaultDeps())
   const fallbackMinutes = spec.timeoutMs > 0 ? spec.timeoutMs / 60_000 : SubsystemPhase.DEFAULT_PHASE_BUDGET_MINUTES
   const budget = await readBudget(deps.readFile, SubsystemPhase.budgetsPath(spec.home), spec.phase, fallbackMinutes)
   const limitMs = Math.round(budget.minutes * 60_000)
+  const fallbackResolution = spec.fallback
+  const fallbackConfig = fallbackResolution?.status === "available" ? fallbackResolution.config : undefined
+  const fallbackAvailable =
+    fallbackConfig !== undefined && deps.provider.capabilities.localResponses && deps.provider.capabilities.dynamicTools
   const budgetWarnings = [
     budget.warning,
-    ...(spec.fallback?.status === "unavailable" ? [spec.fallback.warning] : []),
+    ...(fallbackResolution?.status === "unavailable" ? [fallbackResolution.warning] : []),
   ].filter((item): item is string => Boolean(item))
   const beforeSetup = now()
   const initialDeadline = beforeSetup + limitMs
   const initialEffectiveLimitMs = limitMs
 
-  const instructionLoad = await loadPhaseDeveloperInstructions(spec, deps.readFile).then(
+  const instructionLoad = await loadPhaseDeveloperInstructions(spec, deps.readFile, fallbackAvailable).then(
     (value) => ({ ok: true as const, value }),
     (error) => ({ ok: false as const, error }),
   )
@@ -1171,20 +1252,17 @@ export async function runPhase(spec: PhaseSpec, deps: PhaseDeps = defaultDeps())
   const writeTranscript = deps.writeTranscript
   const persist = Boolean(spec.transcriptPath) && Boolean(writeTranscript) && DependencyConfig.expertTranscriptEnabled()
   const stream = Boolean(onActivity) || persist
-  const fallbackAttempts: FallbackAttemptStatus[] = []
-  let assistUsed = false
-  const fallbackResolution = spec.fallback
-  const fallbackConfig = fallbackResolution?.status === "available" ? fallbackResolution.config : undefined
-  const fallbackAvailable =
-    fallbackConfig !== undefined && deps.provider.capabilities.localResponses && deps.provider.capabilities.dynamicTools
+  const fallbackAttempts: FallbackAssistStatus[] = []
+  let assistAttempt = 0
+  let assistQueue = Promise.resolve()
   const remainingBudgetMs = () => Math.max(0, limitMs - Math.max(0, now() - startedAt - approvalState.pausedMs()))
   const assistTool: DynamicTool | undefined = fallbackAvailable
     ? {
         definition: {
           type: "function",
-          name: "aggressive_fallback_inference",
+          name: "delegate_to_fallback_inference",
           description:
-            "Pause this session and ask the configured local aggressive controller to complete one bounded helper task, then return its concise result and evidence paths.",
+            "Delegate one authorized operation that the primary subsystem cannot complete to the configured local fallback, then return its concise result and evidence paths.",
           inputSchema: {
             type: "object",
             additionalProperties: false,
@@ -1193,87 +1271,109 @@ export async function runPhase(spec: PhaseSpec, deps: PhaseDeps = defaultDeps())
               success_criteria: { type: "string", minLength: 1, maxLength: 4_000 },
               relevant_artifacts: {
                 type: "array",
+                description:
+                  "Workarea-relative paths only. Absolute paths and paths that escape the workarea are rejected.",
                 maxItems: 20,
-                items: { type: "string", minLength: 1, maxLength: 1_024 },
+                items: {
+                  type: "string",
+                  description: "A path relative to the current phase workarea.",
+                  minLength: 1,
+                  maxLength: 1_024,
+                },
               },
             },
             required: ["task", "success_criteria"],
           },
         },
-        execute: async (value) => {
-          if (assistUsed)
-            return { success: false, text: "Only one aggressive fallback assist is allowed in this phase." }
-          assistUsed = true
+        execute: async (value, context) => {
+          // Validate before the call enters the serialized owner. A malformed request consumes neither
+          // an attempt index nor phase budget and can therefore be corrected by the primary immediately.
           const args = assistArguments(value, spec.workareaCwd)
-          const remaining = remainingBudgetMs()
-          if (remaining <= 0) return { success: false, text: "The phase budget is exhausted." }
-          const body = [
-            "## Helper task",
-            args.task,
-            "",
-            "## Success criteria",
-            args.successCriteria,
-            "",
-            "## Relevant durable artifacts",
-            args.relevantArtifacts.length
-              ? args.relevantArtifacts.map((item) => `- ${item}`).join("\n")
-              : "Read the workarea.",
-          ].join("\n")
-          let execution: FallbackExecution
-          try {
-            execution = await executeFallback({
-              mode: "assist",
-              spec,
-              deps,
-              config: fallbackConfig,
-              trustBoundaryInstructions: instructionLoad.value.trustBoundaryInstructions,
-              timeoutMs: remaining,
-              prompt: fallbackPrompt({
+          const pending = assistQueue.then(async () => {
+            if (context.signal.aborted || spec.abort?.aborted)
+              return { success: false, text: "The fallback delegation was cancelled." }
+            const remaining = remainingBudgetMs()
+            if (remaining <= 0) return { success: false, text: "The phase budget is exhausted." }
+            const attempt = ++assistAttempt
+            const body = [
+              "## Helper task",
+              args.task,
+              "",
+              "## Success criteria",
+              args.successCriteria,
+              "",
+              "## Relevant durable artifacts",
+              args.relevantArtifacts.length
+                ? args.relevantArtifacts.map((item) => `- ${item}`).join("\n")
+                : "Read the workarea.",
+            ].join("\n")
+            let execution: FallbackExecution
+            try {
+              execution = await executeFallback({
                 mode: "assist",
-                body,
-                workarea: spec.workareaCwd,
-                minutes: Number((remaining / 60_000).toFixed(2)),
-              }),
-              askQuestion,
-              approvalState,
-              circuitBreakerPath: engagementCircuitBreakerPath,
-              onActivity,
-            })
-          } catch (error) {
+                attempt,
+                spec,
+                deps,
+                config: fallbackConfig,
+                trustBoundaryInstructions: instructionLoad.value.trustBoundaryInstructions,
+                timeoutMs: remaining,
+                abort: context.signal,
+                prompt: fallbackPrompt({
+                  mode: "assist",
+                  body,
+                  workarea: spec.workareaCwd,
+                  minutes: Number((remaining / 60_000).toFixed(2)),
+                }),
+                askQuestion,
+                approvalState,
+                circuitBreakerPath: engagementCircuitBreakerPath,
+                onActivity,
+              })
+            } catch (error) {
+              fallbackAttempts.push({
+                mode: "assist",
+                trigger: "model_delegation",
+                attempt,
+                adapter: deps.provider.name,
+                model: fallbackConfig.model,
+                instructionMode: deps.provider.capabilities.baseInstructions,
+                result: "fallback_unavailable",
+              })
+              return { success: false, text: `fallback_unavailable: ${errorDetail(error)}` }
+            }
+            const completed =
+              processTermination(execution.run) === "completed" &&
+              execution.run.exitCode === 0 &&
+              execution.gatewayExited &&
+              execution.summary.trim().length > 0
             fallbackAttempts.push({
               mode: "assist",
-              trigger: "voluntary",
+              trigger: "model_delegation",
+              attempt,
               adapter: deps.provider.name,
               model: fallbackConfig.model,
               instructionMode: deps.provider.capabilities.baseInstructions,
-              result: "fallback_unavailable",
+              result: completed
+                ? "completed"
+                : execution.run.failure?.kind === "transport" || processTermination(execution.run) === "spawn_failed"
+                  ? "fallback_unavailable"
+                  : "failed",
+              ...(execution.transcriptPath ? { transcript: path.basename(execution.transcriptPath) } : {}),
             })
-            return { success: false, text: `fallback_unavailable: ${errorDetail(error)}` }
-          }
-          const completed =
-            processTermination(execution.run) === "completed" &&
-            execution.run.exitCode === 0 &&
-            execution.gatewayExited &&
-            execution.summary.trim().length > 0
-          fallbackAttempts.push({
-            mode: "assist",
-            trigger: "voluntary",
-            adapter: deps.provider.name,
-            model: fallbackConfig.model,
-            instructionMode: deps.provider.capabilities.baseInstructions,
-            result: completed
-              ? "completed"
-              : execution.run.failure?.kind === "transport" || processTermination(execution.run) === "spawn_failed"
-                ? "fallback_unavailable"
-                : "failed",
-            ...(execution.transcriptPath ? { transcript: path.basename(execution.transcriptPath) } : {}),
+            return {
+              success: completed,
+              text: completed
+                ? execution.summary
+                : `${execution.run.failure?.kind === "transport" ? "fallback_unavailable" : "fallback_failed"}: ${
+                    execution.run.stderr || execution.summary || "local helper failed"
+                  }`,
+            }
           })
-          return {
-            success: completed,
-            text: completed
-              ? execution.summary
-              : `fallback_unavailable: ${execution.run.stderr || execution.summary || "local helper failed"}`,
-          }
+          assistQueue = pending.then(
+            () => {},
+            () => {},
+          )
+          return pending
         },
       }
     : undefined
@@ -1335,6 +1435,7 @@ export async function runPhase(spec: PhaseSpec, deps: PhaseDeps = defaultDeps())
       termination: "spawn_failed",
     }),
   )
+  await assistQueue
   queueSemanticProgressCapture()
   await checkpointQueue
   const approvalWaitMs = Math.round(approvalState.pausedMs())
@@ -1366,32 +1467,60 @@ export async function runPhase(spec: PhaseSpec, deps: PhaseDeps = defaultDeps())
     ])),
   )
   const primarySummary = deps.provider.extractResultText(primaryRun.stdout)
+  const deliverable = phaseDeliverable(spec)
+  const inspectDeliverable = async (): Promise<{ exists: boolean; warning?: string }> =>
+    deliverable && deps.fileExists
+      ? deps.fileExists(path.join(spec.workareaCwd, deliverable)).then(
+          (exists) => ({ exists }),
+          (error) => ({
+            exists: false,
+            warning: `Could not inspect the required deliverable '${deliverable}': ${errorDetail(error)}`,
+          }),
+        )
+      : { exists: true }
+  let deliverableCheck = await inspectDeliverable()
   let finalRun = primaryRun
   let rawTermination = primaryTermination
   let gatewayExited = primaryGatewayExited
   let handoff = primaryHandoff
   let providerSummary = primarySummary
-  let recoveryStatus: FallbackAttemptStatus | undefined
+  let recoveryStatus: FallbackRecoveryStatus | undefined
   let recovered = false
 
-  // ── Structured Policy Failure Gets One Local Recovery ─────────────
-  // Recovery starts only after the primary process and gateway are collected,
-  // and only from the adapter's terminal structured classification. The local
-  // attempt owns a new process, nonce, gateway, transcript, and handoff signal,
-  // but keeps the exact workarea, scope, circuit breaker, approval ledger, and
-  // remaining active phase budget. A failed recovery never recurses.
-  // ─────────────────────────────────────────────────────────────────
+  const recoveryReasons: FallbackRecoveryReason[] = []
   if (
-    primaryRun.failure?.kind === "security_policy_block" &&
-    fallbackConfig &&
-    deps.provider.capabilities.localResponses &&
-    primaryGatewayExited
-  ) {
+    primaryRun.failure ||
+    primaryTermination === "provider_failed" ||
+    (primaryTermination === "completed" && primaryRun.exitCode !== 0)
+  )
+    recoveryReasons.push("provider_failure")
+  if (!(primaryHandoff.value?.summary ?? primarySummary).trim()) recoveryReasons.push("empty_summary")
+  if (deliverable && !deliverableCheck.exists && !deliverableCheck.warning) recoveryReasons.push("missing_deliverable")
+  if (spec.handoff && primaryHandoff.missing) recoveryReasons.push("missing_handoff")
+  else if (spec.handoff && !primaryHandoff.value) recoveryReasons.push("invalid_handoff")
+
+  // ── Completed Primary Collection Defines Recovery Eligibility ──────
+  // Provider and output-contract failures are recoverable only after the primary
+  // process, gateway, handoff, summary, and deliverable have all been observed.
+  // Setup, cancellation, budget, and host lifecycle failures stay with the host;
+  // they never launch another model. One recovery owns a fresh process and gateway
+  // but inherits the exact workarea, scope, approvals, and remaining active budget.
+  // ─────────────────────────────────────────────────────────────────
+  const recoveryEligible =
+    recoveryReasons.length > 0 &&
+    (primaryTermination === "completed" || primaryTermination === "provider_failed") &&
+    !spec.abort?.aborted &&
+    primaryGatewayExited &&
+    !gatewayExit.warning &&
+    !deliverableCheck.warning &&
+    lifecycleWarnings.length === 0
+  if (recoveryEligible && fallbackConfig && deps.provider.capabilities.localResponses) {
     const remaining = remainingBudgetMs()
     if (remaining > 0) {
       try {
         const execution = await executeFallback({
           mode: "recovery",
+          attempt: 1,
           spec,
           deps,
           config: fallbackConfig,
@@ -1404,6 +1533,7 @@ export async function runPhase(spec: PhaseSpec, deps: PhaseDeps = defaultDeps())
               primary: primaryRun,
               primarySummary,
               approvals: approvalLedger?.snapshot() ?? { accepted: 0, rejected: 0, pending: 0 },
+              reasons: recoveryReasons,
             }),
             workarea: spec.workareaCwd,
             minutes: Number((remaining / 60_000).toFixed(2)),
@@ -1414,15 +1544,21 @@ export async function runPhase(spec: PhaseSpec, deps: PhaseDeps = defaultDeps())
           onActivity,
         })
         lifecycleWarnings.push(...execution.warnings)
+        deliverableCheck = await inspectDeliverable()
+        const recoverySummary = execution.handoff?.summary ?? execution.summary
         const recoveryCompleted =
           processTermination(execution.run) === "completed" &&
           execution.run.exitCode === 0 &&
           execution.gatewayExited &&
-          execution.summary.trim().length > 0 &&
+          recoverySummary.trim().length > 0 &&
+          deliverableCheck.exists &&
+          !deliverableCheck.warning &&
           (!spec.handoff || (execution.handoff !== undefined && !execution.handoffWarning))
         recoveryStatus = {
           mode: "recovery",
-          trigger: "security_policy_block",
+          trigger: "primary_failure",
+          attempt: 1,
+          reasons: recoveryReasons,
           adapter: deps.provider.name,
           model: fallbackConfig.model,
           instructionMode: deps.provider.capabilities.baseInstructions,
@@ -1446,13 +1582,15 @@ export async function runPhase(spec: PhaseSpec, deps: PhaseDeps = defaultDeps())
           recovered = true
         } else {
           lifecycleWarnings.push(
-            `Local fallback recovery failed after the primary ${primaryRun.failure.providerCode ?? "security policy"} block.`,
+            `Local fallback recovery failed after primary failure (${recoveryReasons.join(", ")}).`,
           )
         }
       } catch (error) {
         recoveryStatus = {
           mode: "recovery",
-          trigger: "security_policy_block",
+          trigger: "primary_failure",
+          attempt: 1,
+          reasons: recoveryReasons,
           adapter: deps.provider.name,
           model: fallbackConfig.model,
           instructionMode: deps.provider.capabilities.baseInstructions,
@@ -1461,28 +1599,11 @@ export async function runPhase(spec: PhaseSpec, deps: PhaseDeps = defaultDeps())
         lifecycleWarnings.push(`fallback_unavailable: ${errorDetail(error)}`)
       }
     } else {
-      recoveryStatus = {
-        mode: "recovery",
-        trigger: "security_policy_block",
-        adapter: deps.provider.name,
-        model: fallbackConfig.model,
-        instructionMode: deps.provider.capabilities.baseInstructions,
-        result: "failed",
-      }
-      lifecycleWarnings.push("The primary security policy block left no active phase budget for local recovery.")
+      lifecycleWarnings.push(
+        `Primary failure (${recoveryReasons.join(", ")}) left no active phase budget for local recovery.`,
+      )
     }
   }
-  const deliverable = phaseDeliverable(spec)
-  const deliverableCheck =
-    deliverable && deps.fileExists
-      ? await deps.fileExists(path.join(spec.workareaCwd, deliverable)).then(
-          (exists) => ({ exists, warning: undefined }),
-          (error) => ({
-            exists: false,
-            warning: `Could not inspect the required deliverable '${deliverable}': ${errorDetail(error)}`,
-          }),
-        )
-      : ({ exists: true, warning: undefined } as const)
   const deliverableExists = deliverableCheck.exists
   // REPORT.md is intentionally finalized later by the host's variable-resolution/PDF boundary. Its
   // manifest is written there; hashing it here would become stale after that authorized host mutation.
@@ -1578,6 +1699,7 @@ export async function runPhase(spec: PhaseSpec, deps: PhaseDeps = defaultDeps())
     deliverableExists &&
     !manifestWarning &&
     gatewayExited &&
+    (!recoveryStatus || recoveryStatus.result === "completed") &&
     !handoffWarning &&
     !readinessWarning
   const warnings = [

--- a/cyberful/src/subsystem/provider.ts
+++ b/cyberful/src/subsystem/provider.ts
@@ -86,6 +86,7 @@ export type PhaseActivityActor = {
   id: string
   label?: string
   parentID?: string
+  role?: "fallback"
 }
 
 export type PhaseActivityActorState = "started" | "active" | "interacted" | "completed" | "interrupted" | "failed"

--- a/cyberful/src/subsystem/status.test.ts
+++ b/cyberful/src/subsystem/status.test.ts
@@ -39,7 +39,11 @@ describe("subsystem readiness", () => {
       runtime,
       inspectVersion: async () => ({ status: "mismatch", version: "2.0.0" }),
       inspectLogin: async () => true,
-      inspectFallback: async () => ({ status: "disabled", reason: "missing" }),
+      inspectFallback: async () => ({
+        status: "disabled",
+        reason: "missing",
+        warning: "fallback-server.yaml is missing; local fallback inference is disabled for this run.",
+      }),
     })
     expect(degraded).toEqual({
       primary: { name: "codex", model: "gpt-test", version: "2.0.0", status: "degraded" },

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -18,8 +18,8 @@ fresh Codex app-server ── private phase gateway
         │                         └── headless OWASP ZAP
         └── validated handoff ── next fresh process
 
-terminal structured security-policy block
-        └── reap primary ── one local recovery ── validate the same phase handoff
+recoverable primary or output-contract failure
+        └── reap and collect primary ── one local recovery ── validate the same phase handoff
 ```
 
 Every sequential phase gets a new Codex process and private gateway. Advancement
@@ -32,10 +32,11 @@ published only through bounded read-only gateway operations.
 
 The optional fallback is loaded once from `fallback-server.yaml` in the launch
 directory and enabled only after a loopback preflight. It is not another normal
-workflow route: a phase may use one voluntary helper, and only a structured
-terminal provider security-policy block may start one automatic recovery. Both
-inherit the phase scope, workarea, active budget, approval decisions, gateway
-controls, rate limits, and circuit breakers. Details are in
+workflow route: the primary may make serialized autonomous delegations without
+a numeric cap while budget remains, and the host may start one recovery after a
+recoverable primary execution fails or leaves its output contract incomplete.
+Both inherit phase scope, workarea, active budget, approval decisions, gateway
+controls, rate limits, and circuit breakers; neither may recurse. Details are in
 [Local fallback inference](../runtimes/fallback-inference.md).
 
 The workarea remains model-writable evidence space, but ownership is narrow:

--- a/docs/concepts/execution-model.md
+++ b/docs/concepts/execution-model.md
@@ -95,29 +95,38 @@ grants, and ephemeral credentials do not leak across phases.
 ## Local fallback sessions
 
 When `fallback-server.yaml` passes its startup preflight, the primary subsystem
-can call one `aggressive_fallback_inference` helper per phase. Cyberful suspends
-the primary session while a new local controller works through a reduced,
-default-deny `aggressive-assist` gateway. The helper cannot request handoff or
-invoke itself; it returns a concise result and evidence references to the
-primary session, which retains responsibility for the deliverable.
+receives `delegate_to_fallback_inference` and a conditional nudge. When an
+authorized operation requires a more aggressive approach but the primary cannot
+proceed, it delegates autonomously; ordinary executable work remains primary.
+Calls are serialized and have no numeric cap while active phase budget remains.
+Each starts a fresh local controller through a reduced, default-deny
+`fallback-assist` gateway and owns a distinct attempt number and transcript.
+Arguments are validated before an attempt is reserved, and `relevant_artifacts`
+accepts only workarea-relative paths. An assist cannot request handoff or see the
+delegation tool, so it cannot recurse; the primary retains phase responsibility.
 
-Automatic recovery is narrower. It runs once only after the terminal provider
-failure is structurally classified as `security_policy_block`; buffering,
-matching prose, and generic provider errors do not qualify. Cyberful first
-collects the primary process and gateway, then starts a fresh local session and
-`aggressive-recovery` gateway in the same run, phase, workarea, scope, and
-remaining active budget. A sanitized recovery capsule describes the incomplete
-operation and durable artifacts without copying the transcript, reasoning,
-credentials, or raw payloads. Recovery can complete the phase handoff but
-cannot recurse. Local sessions receive the configured compact system prompt
-followed by the same embedded trust boundary; Cyberful does not forward the
-primary phase persona or skill catalog.
+Automatic recovery runs once after Cyberful has collected the primary process,
+gateway, effective summary, deliverable state, and handoff. It applies to any
+provider failure, an empty effective summary, a missing deliverable, or a missing
+or invalid handoff. A structured `security_policy_block` such as `cyberPolicy`
+is one provider-failure case, not the sole trigger. Cancellation, shutdown,
+budget exhaustion, setup or spawn failure, a primary gateway that is still live,
+and host cleanup, sealing, or readiness failures never start recovery.
+
+An eligible failure starts one fresh `fallback-recovery` session in the same run,
+phase, workarea, scope, and remaining active budget. A sanitized capsule describes
+the deterministic reasons and durable state without copying transcript, reasoning,
+credentials, or raw payloads. Recovery may complete handoff, cannot see the
+delegation tool, and is never retried automatically. Local sessions receive the
+configured compact system prompt followed by the same embedded trust boundary;
+Cyberful does not forward the primary phase persona or skill catalog.
 
 Accepted and declined approvals are matched by their exact request envelope and
 automatically reused only inside the same run and phase. A genuinely new action
-still asks the human. Fallback sessions receive distinct transcripts, while a
-host-owned runtime manifest records their public outcome without API keys or
-the configured system prompt. See
+still asks the human. Fallback sessions receive distinct transcripts, while
+runtime manifest version 2 records each attempt, its discriminated trigger and
+recovery reasons, and its public outcome without API keys or the configured
+system prompt. See
 [Local fallback inference](../runtimes/fallback-inference.md).
 
 For repository workflows, imported source and durable source snapshots live in

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -21,9 +21,10 @@ not permission to place a real credential in Git history even briefly.
 `make test-all` adds network, ZAP, and Codex contracts.
 
 The fallback network tier starts a real loopback Responses fixture, confirms
-preflight and tool calling, injects a terminal `cyberPolicy` failure, and checks
-that local recovery completes the phase. It is kept out of the default Bun tier
-because restricted sandboxes may forbid binding a loopback socket.
+preflight and multiple serialized tool calls, injects a non-`cyberPolicy`
+provider failure, and checks that local recovery completes the phase. It is kept
+out of the default Bun tier because restricted sandboxes may forbid binding a
+loopback socket.
 
 GitHub CI/CD is temporarily disabled. Until it is activated, maintainers run the
 relevant commands above locally and record which checks passed. The workflow

--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -36,7 +36,8 @@ dedicated engagement directory and keep Docker running for the full session.
 The local Responses server is optional and operator-owned. Start it before
 Cyberful, place `fallback-server.yaml` in the launch directory, and use a build
 whose Responses API and tool calling are known to work. An unavailable server
-only disables fallback for that run; an unsafe configuration stops startup.
+only disables fallback for that run; a missing file emits one run-level warning,
+while `enabled: false` disables it silently. An unsafe configuration stops startup.
 See [Local fallback inference](../runtimes/fallback-inference.md).
 
 For a source checkout:

--- a/docs/runtimes/fallback-inference.md
+++ b/docs/runtimes/fallback-inference.md
@@ -1,17 +1,16 @@
-# Local aggressive fallback inference
+# Local fallback inference
 
 Cyberful can optionally connect an operator-owned, loopback-only Responses API
 server to a run. Codex remains the primary agentic subsystem. The local server
-is available for one bounded helper call per phase and for one deterministic
-recovery when the primary provider terminally classifies a turn as a cyber
-security-policy block.
+is a bounded delegate for authorized operations the primary cannot execute and
+the owner of one automatic recovery when a primary execution fails recoverably.
+It is not a user-selectable replacement backend or an independent workflow.
 
-The fallback exists so operators can use a local model with their own steering
-for bounded authorized work that a hosted provider cannot complete. It inherits
-the phase workarea, engagement scope, gateway controls, rate limits, CAPTCHA
-circuit breaker, human decisions, and remaining active budget. It never expands
-authorization. Its compact tool surface reduces prefill and catalog noise; it
-is not a security sandbox because shell tools remain intentionally general.
+Fallback inherits the phase workarea, engagement scope, gateway controls, rate
+limits, CAPTCHA circuit breaker, human decisions, and remaining active budget.
+It never expands authorization. Its compact tool surface reduces prefill and
+catalog noise; it is not a security sandbox because shell remains intentionally
+general.
 
 ## Configure the server
 
@@ -25,86 +24,106 @@ base_url: http://127.0.0.1:8000/v1
 model: deepseek-v4-flash
 api_key_env: CYBERFUL_FALLBACK_API_KEY # optional
 system_prompt: |
-  You are the local aggressive controller for an authorized security test.
+  You are the local fallback controller for an authorized security test.
   Complete the supplied bounded operation inside the exact engagement scope.
 ```
 
-The source checkout already provides this ds4-compatible configuration at the
-repository root. Start ds4 before `make run`, for example:
+The source checkout provides this ds4-compatible configuration at the repository
+root. Start ds4 before `make run`, for example:
 
 ```sh
 ./ds4-server --ctx 100000 --kv-disk-dir /tmp/ds4-kv --kv-disk-space-mb 8192
 ```
 
-Cyberful reads and validates this file once when the run starts, before any
-workarea worker is created. `base_url` must be an HTTP or HTTPS loopback URL at
-the `/v1` root; credentials, query strings, fragments, remote hosts, inline
-secrets, unknown fields, and system prompts over 8 KiB are rejected. When
-`api_key_env` is present, the named uppercase environment variable must exist.
-Its value is used only for server requests and is excluded from the model's
-shell environment. At execution time Cyberful appends its embedded
-target-content trust boundary to the configured `system_prompt`. It does not
-forward the primary phase persona, delegation policy, or first-party skill
-catalog to the compact local session.
+Cyberful reads and validates the file once when the run starts, before creating
+workers. `base_url` must be an HTTP or HTTPS loopback URL at the `/v1` root;
+credentials, query strings, fragments, remote hosts, inline secrets, unknown
+fields, and system prompts over 8 KiB are rejected. When `api_key_env` is
+present, the named uppercase environment variable must exist. Its value stays
+host-side. At execution time Cyberful appends its embedded target-content trust
+boundary to the configured `system_prompt`; it does not forward the primary
+persona, delegation policy, or first-party skill catalog.
 
-A missing file or `enabled: false` disables fallback. An invalid or unsafe file
-stops startup. An unreachable server produces a warning, lets the primary run
-start, and omits `aggressive_fallback_inference` for the complete run. Cyberful
-does not probe again in the background. If a server that passed preflight later
-disappears, the attempt returns `fallback_unavailable`; provider request and
-stream retry counts remain zero.
+Availability is frozen for the complete run:
+
+- a missing file emits one run-level warning, records `disabled/missing`, and
+  exposes neither the delegation tool nor its nudge;
+- `enabled: false` records intentional disablement silently and also omits both;
+- an invalid or unsafe file stops startup;
+- an unreachable configured server emits the preflight warning and remains
+  unavailable, with no background retry and no tool or nudge;
+- a server that disappears after successful preflight makes that invocation
+  return `fallback_unavailable`; provider request and stream retries remain zero.
 
 The server must implement the OpenAI Responses wire protocol, including working
-tool calls. [antirez/ds4](https://github.com/antirez/ds4) is the default: its
-server exposes `/v1/models`, `/v1/responses`, Responses streaming, and tool
-calls on port 8000. Other suitable operator-managed runtimes include
+tool calls. [antirez/ds4](https://github.com/antirez/ds4) is the default. Other
+operator-managed runtimes such as
 [llama.cpp server](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md)
-that expose a compatible `/v1/responses` endpoint. Availability of a generic
-HTTP or chat-completions endpoint is not sufficient.
+are suitable only when their `/v1/responses` implementation and tool calling are
+compatible; a generic HTTP or chat-completions endpoint is insufficient.
 
-## Voluntary assist
+## Autonomous delegation
 
-When preflight succeeds, the primary subsystem receives this dynamic host tool:
+After successful preflight, the primary receives this dynamic host tool:
 
 ```text
-aggressive_fallback_inference({
+delegate_to_fallback_inference({
   task: string,
   success_criteria: string,
-  relevant_artifacts?: string[]
+  relevant_artifacts?: string[] // workarea-relative paths only
 })
 ```
 
-The call suspends the primary turn while a fresh local controller works in the
-same workarea. The controller reads durable artifacts, uses the
-`aggressive-assist` gateway profile, and returns a concise result plus evidence
-paths. It cannot call `handoff`, does not see the fallback tool, and therefore
-cannot recurse. The primary resumes and remains responsible for its deliverable.
-Only one voluntary assist is allowed per phase.
+The primary also receives a conditional nudge: if an authorized action needs a
+more aggressive approach and the primary cannot proceed, it should delegate the
+bounded operation autonomously. Work the primary can execute normally remains
+in the primary session. The operator does not select fallback manually.
 
-## Deterministic recovery
+Arguments are validated before Cyberful reserves an attempt index or starts a
+server. In particular, `relevant_artifacts` rejects absolute paths and paths that
+escape the workarea, so a corrected retry remains possible after invalid input.
+Valid calls are serialized. They have no numeric cap while phase budget remains;
+each receives a fresh local process, gateway, and transcript such as
+`fallback-assist-1`, `fallback-assist-2`, and so on.
 
-Codex maps terminal provider failures to the shared `ProviderFailure` taxonomy.
-Automatic recovery is triggered only when the completed turn contains
-`codexErrorInfo === "cyberPolicy"`. Similar prose, preliminary safety buffering,
-and generic provider errors do not trigger it.
+An assist uses the default-deny `fallback-assist` profile and returns a concise
+result and evidence paths to the suspended primary. It cannot call `handoff`,
+does not receive `delegate_to_fallback_inference`, and therefore cannot recurse.
+The primary retains responsibility for the phase deliverable and handoff.
+While an assist or recovery is running, the TUI marks its host-owned actor in
+orange and labels the numbered attempt explicitly. Completion and failure retain
+their normal green or red lifecycle state, while attributed fallback work keeps
+the orange label.
 
-After such a block Cyberful:
+## Automatic recovery
 
-1. fully collects the primary process and gateway;
-2. starts one local attempt with a fresh process, nonce, gateway, handoff signal,
-   and transcript;
-3. supplies a sanitized recovery capsule of at most 16 KiB and tells the model
-   to read durable workarea evidence;
-4. uses only the phase's remaining active budget; human waits remain excluded;
-5. lets the `aggressive-recovery` controller finish the interrupted deliverable
-   and own the required handoff;
-6. never starts another fallback if this attempt fails.
+Cyberful evaluates recovery only after it has completely collected the primary
+process, gateway, effective summary, required deliverable, and handoff. It
+records one or more deterministic reasons:
 
-The capsule includes the phase objective, required deliverable, checkpoint
-reference, public provider state, incomplete-operation warning, and structured
+- `provider_failure` for a structured or generic provider failure;
+- `empty_summary` when the effective summary is empty;
+- `missing_deliverable` when the required phase artifact is absent;
+- `missing_handoff` when no required handoff was recorded;
+- `invalid_handoff` when a recorded handoff violates the phase contract.
+
+Any of those reasons may start exactly one non-recursive recovery for that
+primary execution. Cyber-threat policy classification, including
+`codexErrorInfo === "cyberPolicy"`, is one source of `provider_failure`, not the
+only trigger. Cyberful does not start recovery for cancellation, host shutdown,
+budget exhaustion, setup or spawn failure, a primary gateway that has not exited,
+or host cleanup, artifact sealing, and readiness errors. It never automatically
+retries a failed recovery.
+
+An eligible recovery starts a fresh local process, nonce, `fallback-recovery`
+gateway, handoff signal, and transcript. It receives the exact remaining active
+phase budget and a sanitized capsule capped at 16 KiB. The capsule contains the
+phase objective, required deliverable, checkpoint reference, deterministic
+reasons, public provider state, incomplete-operation warning, and structured
 error code. It excludes the full transcript, hidden reasoning, credentials,
-secrets, and raw operational payloads. If prior work may already have produced
-an effect, the recovery is instructed to verify observable state before replay.
+secrets, and raw operational payloads. The recovery verifies possible prior
+effects before replay, may complete the required handoff, cannot invoke fallback,
+and does not replace the preserved original provider error.
 
 ## Approval continuity
 
@@ -117,40 +136,47 @@ another phase or run.
 
 ## Compact gateway profiles
 
-`aggressive-assist` and `aggressive-recovery` are default-deny at both tool
-listing and direct-call boundaries. First-party versioned metadata selects
-isolated shell, active HTTP and session testing, credential testing, fuzzing,
-exploitation, binary/mobile/Active Directory work, browser interaction, active
-ZAP operations, CAPTCHA/question flow, and evidence collection. Recovery alone
+`fallback-assist` and `fallback-recovery` are default-deny at both tool listing
+and direct-call boundaries. Assist eagerly receives only shell and compact
+evidence/discovery tools from cyberful-os; it can query a narrow
+`tool_inventory` category on demand and execute the selected command through the
+already-authorized shell. Recovery additionally receives isolated tools carrying
+the neutral `active` role because it may own the complete interrupted phase.
+Both profiles explicitly include browser interaction, active ZAP operations,
+CAPTCHA/question flow, rate limits, and circuit breakers. Recovery alone
 receives `handoff`.
 
-DNS, subdomain enumeration, host and port scanning, content discovery,
-fingerprinting, passive inventory, and report generators are excluded. The
-profile preserves the parent phase's scope, gateway, rate limits, circuit
-breaker, workarea, and runtime policy.
+Assist omits eager dedicated command schemas; recovery still excludes DNS,
+subdomain enumeration, host and port scanning, content discovery,
+fingerprinting, passive inventory, and report generators. Because shell remains
+general, the profile is an interface reduction rather than a security boundary.
 
-## Evidence and testing
+## Public state and evidence
 
 Primary and fallback transcripts are separate:
 
 ```text
 session-ses_....expert-hacker.jsonl
 session-ses_....expert-hacker.fallback-assist-1.jsonl
+session-ses_....expert-hacker.fallback-assist-2.jsonl
 session-ses_....expert-hacker.fallback-recovery-1.jsonl
 ```
 
-Public phase status and `raw/phase-manifests/<workflow>/<phase>.runtime.json`
-record the server state, mode, trigger, adapter, model, instruction override
-mode, outcome, and `recovered` flag. They never record an API key or the complete
-configured system prompt. Report phases read these manifests and disclose a
-material fallback failure or unrecovered block as a coverage limitation.
+Runtime manifest version 2 records every invocation with its attempt number,
+adapter, model, instruction override mode, outcome, and transcript. Assist entries
+use `mode: assist` and `trigger: model_delegation`; recovery uses
+`mode: recovery`, `trigger: primary_failure`, and the `reasons` list. The public
+phase status also records server state and the `recovered` flag. Neither surface
+stores an API key, base URL, or configured system prompt.
 
-Run the loopback Responses lifecycle contract with:
+Run the real loopback lifecycle contract with:
 
 ```sh
 make test-network
 ```
 
-The ordinary unit suite covers configuration, structured classification,
-approval replay, budget ownership, gateway lifecycle, recursion prevention,
-tool filtering, recovery advancement, and failure preservation.
+The network test performs multiple delegations and a non-`cyberPolicy` recovery.
+The ordinary suites cover missing/disabled/unreachable configuration, argument
+retry, serialization, provider classes, output-contract reasons, exclusion
+conditions, approval replay, budget ownership, gateway lifecycle, recursion
+prevention, tool filtering, recovery advancement, and original-error preservation.

--- a/mcps/cyberful-os/cyberful_os_mcp.py
+++ b/mcps/cyberful-os/cyberful_os_mcp.py
@@ -793,7 +793,7 @@ ToolHandler = Callable[[dict[str, Any]], dict[str, Any]]
 ToolEntry = tuple[str, str, dict[str, Any], ToolHandler]
 TOOL_REGISTRY: list[ToolEntry] = []
 
-AGGRESSIVE_CLI_CATEGORIES = frozenset(
+ACTIVE_CLI_CATEGORIES = frozenset(
     {
         "active-directory",
         "credentials",
@@ -805,7 +805,7 @@ AGGRESSIVE_CLI_CATEGORIES = frozenset(
         "windows",
     }
 )
-AGGRESSIVE_CLI_TOOLS = frozenset(
+ACTIVE_CLI_TOOLS = frozenset(
     {
         "bettercap",
         "commix",
@@ -837,26 +837,29 @@ RECON_CLI_TOOLS = frozenset(
 
 
 # ── Fallback Roles Are Catalog Metadata, Not Prompt Heuristics ─────────
-# A local recovery session should see active tools without paying the prefill
-# cost of the entire reconnaissance catalog. Roles are derived from the verified
-# first-party registry and emitted in MCP metadata, never guessed from prose.
-# Unknown and passive tools receive no aggressive role and are therefore denied
-# by the gateway's default-deny fallback profile at both listing and call time.
+# A local assist should discover the catalog on demand and use the general shell
+# without paying the prefill cost of every dedicated command schema. Recovery
+# retains active tools because it may own the whole interrupted phase. Roles are
+# derived from the verified first-party registry and emitted in MCP metadata,
+# never guessed from prose; the gateway applies the mode-specific allowlist at
+# both listing and call time.
 # ──────────────────────────────────────────────────────────────────────
 def _fallback_tool_roles(name: str) -> list[str]:
     if name == "shell":
         return ["shell"]
+    if name == "tool_inventory":
+        return ["evidence"]
     if name in {"requests", "bs4", "lxml"}:
-        return ["aggressive", "evidence"]
+        return ["active", "evidence"]
     spec = next((candidate for candidate in CLI_TOOL_SPECS if candidate.name == name), None)
     if spec is None:
         return []
     if name in RECON_CLI_TOOLS or spec.category in {"dns", "osint"}:
         return ["recon"]
     if name in EVIDENCE_CLI_TOOLS:
-        return ["aggressive", "evidence"]
-    if name in AGGRESSIVE_CLI_TOOLS or spec.category in AGGRESSIVE_CLI_CATEGORIES:
-        return ["aggressive"]
+        return ["active", "evidence"]
+    if name in ACTIVE_CLI_TOOLS or spec.category in ACTIVE_CLI_CATEGORIES:
+        return ["active"]
     return []
 
 

--- a/mcps/cyberful-os/tests/test_capability_attestation.py
+++ b/mcps/cyberful-os/tests/test_capability_attestation.py
@@ -91,11 +91,12 @@ class CapabilityReportTest(unittest.TestCase):
 
     def test_fallback_profiles_use_versioned_first_party_roles(self):
         self.assertEqual(cyberful_os_mcp._fallback_tool_roles("shell"), ["shell"])
-        self.assertIn("aggressive", cyberful_os_mcp._fallback_tool_roles("requests"))
+        self.assertEqual(cyberful_os_mcp._fallback_tool_roles("tool_inventory"), ["evidence"])
+        self.assertIn("active", cyberful_os_mcp._fallback_tool_roles("requests"))
         self.assertIn("evidence", cyberful_os_mcp._fallback_tool_roles("requests"))
         self.assertIn("recon", cyberful_os_mcp._fallback_tool_roles("nmap"))
-        self.assertNotIn("aggressive", cyberful_os_mcp._fallback_tool_roles("nmap"))
-        self.assertIn("aggressive", cyberful_os_mcp._fallback_tool_roles("afl_fuzz"))
+        self.assertNotIn("active", cyberful_os_mcp._fallback_tool_roles("nmap"))
+        self.assertIn("active", cyberful_os_mcp._fallback_tool_roles("afl_fuzz"))
         self.assertIn("evidence", cyberful_os_mcp._fallback_tool_roles("tcpdump"))
         self.assertEqual(cyberful_os_mcp._fallback_tool_roles("wordlists"), [])
 


### PR DESCRIPTION
**Implemented a broader, autonomous fallback inference flow.**

The primary subsystem can now call `delegate_to_fallback_inference` whenever an authorized action requires a more capable or aggressive approach that it cannot complete itself. Delegations are serialized but no longer capped, and each invocation receives its own numbered gateway, transcript, manifest entry, and TUI activity row.

Fallback availability is checked at startup. If `fallback-server.yaml` is missing or the configured server is unreachable, Cyberful emits a warning and omits both the tool and its prompt nudge. An explicitly disabled fallback remains silent.

Automatic recovery now covers general primary-phase failures—not only cyber-policy blocks—including provider failures, empty summaries, missing deliverables, and missing or invalid handoffs. Recovery remains single-attempt and non-recursive, while preserving the original failure reason.

We also:

- Renamed the profiles to `fallback-assist` and `fallback-recovery`, and the MCP role from `aggressive` to `active`.
- Restricted `relevant_artifacts` to workarea-relative paths and validate arguments before reserving an attempt.
- Prevented fallback sessions from recursively delegating or producing assist handoffs.
- Reduced the assist tool inventory from 113 tools to 7 eagerly loaded tools, cutting the observed initial prompt from roughly 48K to 13.4K tokens.
- Added an orange TUI indicator whenever fallback inference is active.
- Updated runtime manifests to version 2 with attempt numbers, triggers, and deterministic recovery reasons.
- Updated the README, architecture documentation, and fallback runtime guide.

The live smoke test successfully performed two independent fallback delegations—one ping and one curl against `example.com`—with separate transcripts and evidence files. Type checks, Bun and Python test suites, gateway tests, TUI tests, and the documentation build all pass.