### PR TITLE
Fail closed for optional runtime tool discovery

### DIFF
--- a/docs/runtimes/cyberful-os.md
+++ b/docs/runtimes/cyberful-os.md
@@ -75,6 +75,13 @@ verifies the supplied running container, ownership labels, and workspace mount.
 It cannot create, replace, or restart it. Standalone MCP use retains lazy local
 container creation.
 
+Tool discovery is derived from the live capability preflight. Required tools
+remain part of the image contract, while optional tools fail closed until the
+selected image proves they are installed. JEB therefore appears only for a
+private image built with its licensed installer; running
+`capability_attestation` refreshes the snapshot used by discovery, while
+`tool_inventory` independently reports the current live availability.
+
 ## Configuration
 
 | Variable | Default | Meaning |

--- a/mcps/README.md
+++ b/mcps/README.md
@@ -81,7 +81,9 @@ refresh to a newer signed release.
 Use `tool_inventory` to list registered MCP names, real commands/modules,
 categories, aliases, optional tools, and live availability inside the current
 container. `jeb` is optional and only resolves when a private image build
-includes JEB.
+includes JEB. Optional tools fail closed during discovery until the shared
+runtime preflight proves their command or module is installed; an explicit
+`capability_attestation` refreshes that same snapshot.
 
 `capability_attestation` checks every required catalog command and Python module
 and smoke-tests Nuclei and Metasploit without target traffic. The Dockerfile runs

--- a/mcps/cyberful-os/cyberful_os_mcp.py
+++ b/mcps/cyberful-os/cyberful_os_mcp.py
@@ -1810,9 +1810,13 @@ def ensure_strict_preflight() -> None:
 
 
 def handle_capability_attestation(args: dict[str, Any]) -> dict[str, Any]:
-    report = container_capability_report(args)
-    _write_capability_attestation(report)
-    return tool_result(json.dumps(report, indent=2, sort_keys=True) + "\n", is_error=report["status"] != "available")
+    global PREFLIGHT_REPORT
+    PREFLIGHT_REPORT = container_capability_report(args)
+    _write_capability_attestation(PREFLIGHT_REPORT)
+    return tool_result(
+        json.dumps(PREFLIGHT_REPORT, indent=2, sort_keys=True) + "\n",
+        is_error=PREFLIGHT_REPORT["status"] != "available",
+    )
 
 
 def handle_tool_inventory(args: dict[str, Any]) -> dict[str, Any]:
@@ -2555,13 +2559,28 @@ Environment variables:
 
 
 def _exposed_tool_registry() -> list[ToolEntry]:
-    if not PREFLIGHT_REPORT:
-        return TOOL_REGISTRY
-    disabled = {
-        tool["name"]
-        for tool in PREFLIGHT_REPORT.get("tools", [])
-        if tool.get("status") == "optional-disabled"
+    # ── Optional Capabilities Fail Closed Until Runtime Proof ────────
+    # Tool discovery can precede an explicit attestation in standalone MCP
+    # clients. Advertising an optional commercial or private-build command in
+    # that window would give the model a tool the selected image cannot run.
+    # Required tools remain part of the strict image contract; optional tools
+    # enter the registry only after the shared preflight snapshot proves them.
+    # ─────────────────────────────────────────────────────────────────
+    optional = {
+        spec.name
+        for spec in (*CLI_TOOL_SPECS, *LIBRARY_TOOL_SPECS)
+        if spec.optional
     }
+    proven_available = (
+        {
+            tool["name"]
+            for tool in PREFLIGHT_REPORT.get("tools", [])
+            if tool.get("name") in optional and tool.get("status") == "available"
+        }
+        if PREFLIGHT_REPORT
+        else set()
+    )
+    disabled = optional - proven_available
     return [tool for tool in TOOL_REGISTRY if tool[0] not in disabled]
 
 

--- a/mcps/cyberful-os/tests/test_capability_attestation.py
+++ b/mcps/cyberful-os/tests/test_capability_attestation.py
@@ -92,6 +92,47 @@ class CapabilityReportTest(unittest.TestCase):
         finally:
             cyberful_os_mcp.PREFLIGHT_REPORT = previous
 
+    def test_incomplete_preflight_does_not_expose_unproven_optional_tools(self):
+        previous = cyberful_os_mcp.PREFLIGHT_REPORT
+        cyberful_os_mcp.PREFLIGHT_REPORT = {"tools": []}
+        try:
+            exposed = {name for name, _, _, _ in cyberful_os_mcp._exposed_tool_registry()}
+            self.assertNotIn("jeb", exposed)
+        finally:
+            cyberful_os_mcp.PREFLIGHT_REPORT = previous
+
+    def test_optional_tools_fail_closed_before_preflight(self):
+        optional = {
+            spec.name
+            for spec in (*cyberful_os_mcp.CLI_TOOL_SPECS, *cyberful_os_mcp.LIBRARY_TOOL_SPECS)
+            if spec.optional
+        }
+        previous = cyberful_os_mcp.PREFLIGHT_REPORT
+        cyberful_os_mcp.PREFLIGHT_REPORT = None
+        try:
+            exposed = {name for name, _, _, _ in cyberful_os_mcp._exposed_tool_registry()}
+            self.assertTrue(optional)
+            self.assertTrue(optional.isdisjoint(exposed))
+            self.assertIn("nuclei", exposed)
+            self.assertIn("capability_attestation", exposed)
+        finally:
+            cyberful_os_mcp.PREFLIGHT_REPORT = previous
+
+    def test_attestation_refreshes_the_registry_snapshot(self):
+        available = {
+            "status": "available",
+            "tools": [{"name": "jeb", "status": "available"}],
+        }
+        with mock.patch.object(cyberful_os_mcp, "PREFLIGHT_REPORT", None), mock.patch.object(
+            cyberful_os_mcp, "container_capability_report", return_value=available
+        ), mock.patch.object(cyberful_os_mcp, "_write_capability_attestation"):
+            result = cyberful_os_mcp.handle_capability_attestation({})
+
+            self.assertFalse(result["isError"])
+            self.assertIs(cyberful_os_mcp.PREFLIGHT_REPORT, available)
+            exposed = {name for name, _, _, _ in cyberful_os_mcp._exposed_tool_registry()}
+            self.assertIn("jeb", exposed)
+
     def test_fallback_profiles_use_versioned_first_party_roles(self):
         self.assertEqual(cyberful_os_mcp._fallback_tool_roles("shell"), ["shell"])
         self.assertEqual(cyberful_os_mcp._fallback_tool_roles("tool_inventory"), ["evidence"])


### PR DESCRIPTION
## What changed

- expose optional runtime tools only after capability preflight explicitly proves them available
- keep JEB supported for licensed private images while hiding it from public images that do not contain it
- refresh the shared discovery snapshot when `capability_attestation` runs
- document the discovery and live-inventory behavior
- add regression coverage for missing, incomplete, disabled, and available optional capabilities

## Root cause

Tool discovery returned the complete registry before a preflight snapshot existed. This advertised JEB even though the public runtime image did not install it, so the native runtime integration test correctly detected catalog/image drift.

## Impact

Runtime discovery now fails closed for every optional capability. Required tools remain governed by the strict image contract. JEB is still exposed when a private licensed build proves the executable is installed.

## Validation

- `python3 -m unittest tests.test_capability_attestation -v`
- `make test-python` — 78 tests passed
- `make typecheck`
- `make docs-build`
- `git diff --check`

A real multi-architecture runtime build and integration test on the dedicated amd64 and arm64 runners is still required after merge.
