### PR TITLE
perf: preserve cyberful-os build cache

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,15 +3,21 @@
 `ci.yml` runs typechecking, local tests, and the strict documentation build for
 pull requests and pushes to `main`.
 
-`runtime.yml` owns `ghcr.io/cyberful/cyberful-os`. Every pull request builds and
-tests native `linux/amd64` and `linux/arm64` images on the two dedicated
-self-hosted runner classes without publishing. A manual run outside `main` is
-the same non-publishing native check. Runs on `main` are queued and processed in
-order. Each native job installs the pinned Patchright Chromium and its Linux
-libraries before exercising browser-through-ZAP; system Chrome is an optional
-additional channel when the runner provides it. Runtime changes push one tested
-native digest per architecture with BuildKit SBOM/provenance, then a bounded
-index job creates
+`runtime.yml` owns `ghcr.io/cyberful/cyberful-os`. Runtime-affecting pull
+requests reach a protected `runtime-pr` environment after the cheap selection
+job; only an explicit deployment review by the repository owner releases AWS
+OIDC and the GitHub runner credential. The approved run creates exactly one
+ephemeral `linux/amd64` and one ephemeral `linux/arm64` EC2 runner without
+publishing. A manual run outside `main` uses the same reviewed path. Runs on
+`main` use the unreviewed, main-only `runtime-main` environment and are queued
+with PR runtime validation in one global FIFO, bounding live capacity to two
+instances. Each native job installs the pinned Patchright Chromium and its
+Linux libraries before exercising browser-through-ZAP; system Chrome is an
+optional additional channel when the runner provides it. Architecture-scoped
+GitHub Actions caches preserve reusable BuildKit layers across the disposable
+instances. Runtime changes push
+one tested native digest per architecture with BuildKit SBOM/provenance, then a
+bounded index job creates
 `sha-<40-character-commit>`, verifies exactly the two executable platforms,
 and signs the immutable digest with Cosign and GitHub OIDC. When that commit is
 still the head of `main`, the same operation also moves `edge` to the identical
@@ -28,6 +34,16 @@ interrupted keyless signature. Checking the live `main` head before moving
 The first successful publication creates the GHCR package. A repository owner
 must then make it public once in package settings; the image source label links
 it back to this repository. See the release guide for that bootstrap step.
+
+`runtime-runner-cleanup.yml` is evaluated from `main` after every completed
+runtime run. It terminates instances carrying the repository's managed tags and
+deletes unused one-time registration parameters; an hourly sweep removes only
+capacity older than four hours. Each runner also shuts itself down after its
+single ephemeral job, and EC2 translates that shutdown into termination. The
+AWS boundary is reproducible from `infra/github-runners.yml`: launch templates
+have no inbound rules, require IMDSv2, use encrypted disposable volumes, and
+grant the instance only permission to consume and delete its one-time SSM
+parameter.
 
 `release.yml` is manual. Run it from `main` with an explicit stable SemVer. It
 resolves and verifies the signed `sha-${GITHUB_SHA}` runtime index, embeds that

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,8 +15,10 @@ instances. Each native job installs the pinned Patchright Chromium and its
 Linux libraries before exercising browser-through-ZAP; system Chrome is an
 optional additional channel when the runner provides it. Architecture-scoped
 GitHub Actions caches preserve final-image BuildKit layers across disposable
-instances without retaining quota-heavy intermediate stages. Runtime changes
-push
+instances without retaining quota-heavy intermediate stages. Pull requests and
+non-main dry-runs consume the base branch cache read-only; only `main` updates
+it, preventing a full image cache from being duplicated for every pull-request
+ref. Runtime changes push
 one tested native digest per architecture with BuildKit SBOM/provenance, then a
 bounded index job creates
 `sha-<40-character-commit>`, verifies exactly the two executable platforms,

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,8 +14,9 @@ with PR runtime validation in one global FIFO, bounding live capacity to two
 instances. Each native job installs the pinned Patchright Chromium and its
 Linux libraries before exercising browser-through-ZAP; system Chrome is an
 optional additional channel when the runner provides it. Architecture-scoped
-GitHub Actions caches preserve reusable BuildKit layers across the disposable
-instances. Runtime changes push
+GitHub Actions caches preserve final-image BuildKit layers across disposable
+instances without retaining quota-heavy intermediate stages. Runtime changes
+push
 one tested native digest per architecture with BuildKit SBOM/provenance, then a
 bounded index job creates
 `sha-<40-character-commit>`, verifies exactly the two executable platforms,

--- a/.github/workflows/runtime-runner-cleanup.yml
+++ b/.github/workflows/runtime-runner-cleanup.yml
@@ -1,0 +1,118 @@
+# ── Ephemeral Runner Cleanup ─────────────────────────────────────
+# Reaps native runtime instances after a workflow completes and sweeps any
+#   capacity that outlives its four-hour instance-side termination deadline.
+# → infra/github-runners.yml — restricts termination to tagged runner capacity.
+# @docs/development/testing.md
+# ─────────────────────────────────────────────────────────────────
+name: Runtime runner cleanup
+
+on:
+  workflow_run:
+    workflows: [Unified runtime]
+    types: [completed]
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: runtime-runner-cleanup
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  AWS_REGION: eu-central-1
+
+jobs:
+  cleanup:
+    name: Terminate completed or expired runner capacity
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment:
+      name: runtime-main
+    permissions:
+      contents: read
+      id-token: write # Exchange GitHub OIDC for runner lifecycle AWS access.
+    steps:
+      - name: Assume the ephemeral runner provisioning role
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          mask-aws-account-id: true
+          role-session-name: cyberful-cleanup-${{ github.run_id }}
+          role-to-assume: ${{ vars.AWS_RUNNER_ROLE_ARN }}
+      - name: Remove completed-run capacity or sweep expired capacity
+        env:
+          COMPLETED_RUN_ID: ${{ github.event.workflow_run.id }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          cutoff_epoch="$(date --utc --date='4 hours ago' +%s)"
+          describe_filters=(
+            'Name=tag:cyberful:managed,Values=true'
+            "Name=tag:cyberful:repository,Values=$REPOSITORY"
+            'Name=instance-state-name,Values=pending,running,stopping,stopped'
+          )
+          if [[ -n "$COMPLETED_RUN_ID" ]]; then
+            describe_filters+=("Name=tag:cyberful:run-id,Values=$COMPLETED_RUN_ID")
+          fi
+
+          instances="$(aws ec2 describe-instances \
+            --region "$AWS_REGION" \
+            --filters "${describe_filters[@]}" \
+            --query 'Reservations[].Instances[]' \
+            --output json)"
+          if [[ -n "$COMPLETED_RUN_ID" ]]; then
+            instance_ids="$(jq --raw-output '.[].InstanceId' <<<"$instances")"
+          else
+            instance_ids="$(jq --raw-output --argjson cutoff "$cutoff_epoch" '
+              .[] | select((.LaunchTime | fromdateiso8601) < $cutoff) | .InstanceId
+            ' <<<"$instances")"
+          fi
+          if [[ -n "$instance_ids" ]]; then
+            read -r -a ids <<<"$(tr '\n' ' ' <<<"$instance_ids")"
+            aws ec2 terminate-instances \
+              --region "$AWS_REGION" \
+              --instance-ids "${ids[@]}" >/dev/null
+            aws ec2 wait instance-terminated \
+              --region "$AWS_REGION" \
+              --instance-ids "${ids[@]}"
+          fi
+
+          if [[ -n "$COMPLETED_RUN_ID" ]]; then
+            parameter_path="/cyberful/github-runners/$COMPLETED_RUN_ID"
+            parameters="$(aws ssm get-parameters-by-path \
+              --region "$AWS_REGION" \
+              --path "$parameter_path" \
+              --recursive \
+              --query 'Parameters[].Name' \
+              --output text)"
+            for parameter in $parameters; do
+              aws ssm delete-parameter \
+                --region "$AWS_REGION" \
+                --name "$parameter"
+            done
+          else
+            parameters="$(aws ssm get-parameters-by-path \
+              --region "$AWS_REGION" \
+              --path /cyberful/github-runners \
+              --recursive \
+              --output json)"
+            jq --raw-output '
+              .Parameters[] | [.Name, (.LastModifiedDate | tostring)] | @tsv
+            ' <<<"$parameters" | while IFS=$'\t' read -r parameter modified; do
+              if [[ "$modified" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+                modified_epoch="${modified%%.*}"
+              else
+                modified_epoch="$(date --date="$modified" +%s)"
+              fi
+              if (( modified_epoch < cutoff_epoch )); then
+                aws ssm delete-parameter \
+                  --region "$AWS_REGION" \
+                  --name "$parameter"
+              fi
+            done
+          fi

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -372,7 +372,6 @@ jobs:
             BUILD_VERSION=check-${{ github.sha }}
             BUILD_REVISION=${{ github.sha }}
           cache-from: type=gha,scope=cyberful-os-${{ env.RUNTIME_ARCH }}
-          cache-to: type=gha,mode=min,scope=cyberful-os-${{ env.RUNTIME_ARCH }},ignore-error=true
           load: true
       - name: Verify architecture and full runtime behavior
         env:

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -1,3 +1,11 @@
+# ── Unified Runtime CI/CD ────────────────────────────────────────
+# Reviews, provisions, tests, publishes, attests, and signs the two native
+#   architectures that form the immutable Cyberful runtime OCI index.
+# → infra/github-runners.yml — defines the ephemeral native runner boundary.
+# → .github/workflows/runtime-runner-cleanup.yml — reaps runner capacity.
+# @docs/development/testing.md
+# @docs/development/release.md
+# ─────────────────────────────────────────────────────────────────
 name: Unified runtime
 
 on:
@@ -6,16 +14,18 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Registry mutations on main must be ordered. queue: max avoids GitHub's default
-# behavior of replacing an already-pending run with the newest one.
+# Native capacity is deliberately global: at most one amd64 and one arm64
+# instance may exist for this repository. queue: max preserves every approved
+# run while serializing PR validation and main publication.
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('runtime-pr-{0}', github.event.pull_request.number) || github.ref == 'refs/heads/main' && 'runtime-main' || format('runtime-{0}', github.run_id) }}
+  group: runtime-native
   queue: max
 
 permissions:
   contents: read
 
 env:
+  AWS_REGION: eu-central-1
   BUN_VERSION: 1.3.14
   RUNTIME_IMAGE: ghcr.io/cyberful/cyberful-os
 
@@ -27,6 +37,7 @@ jobs:
       runtime_changed: ${{ steps.change.outputs.runtime_changed }}
       publish_main: ${{ steps.change.outputs.publish_main }}
       full_build: ${{ steps.change.outputs.full_build }}
+      needs_runners: ${{ steps.change.outputs.needs_runners }}
       sha_exists: ${{ steps.change.outputs.sha_exists }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.0.1
@@ -99,15 +110,175 @@ jobs:
             runtime_changed=true
           fi
 
+          needs_runners=false
+          if [[ "$publish_main" == true && "$full_build" == true && "$sha_exists" == false ]]; then
+            needs_runners=true
+          elif [[ "$publish_main" == false && "$runtime_changed" == true ]]; then
+            needs_runners=true
+          fi
+
           echo "runtime_changed=$runtime_changed" >> "$GITHUB_OUTPUT"
           echo "publish_main=$publish_main" >> "$GITHUB_OUTPUT"
           echo "full_build=$full_build" >> "$GITHUB_OUTPUT"
+          echo "needs_runners=$needs_runners" >> "$GITHUB_OUTPUT"
           echo "sha_exists=$sha_exists" >> "$GITHUB_OUTPUT"
+
+  provision-runners:
+    name: Authorize and provision native runners
+    needs: [prepare]
+    if: needs.prepare.outputs.needs_runners == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment:
+      name: ${{ github.event_name == 'push' && 'runtime-main' || 'runtime-pr' }}
+    permissions:
+      contents: read
+      id-token: write # Exchange GitHub OIDC for the narrowly scoped AWS role.
+    steps:
+      - id: app-token
+        name: Mint a short-lived runner administration token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ vars.CYBERFUL_RUNNER_APP_ID }}
+          private-key: ${{ secrets.CYBERFUL_RUNNER_APP_PRIVATE_KEY }}
+      - name: Assume the ephemeral runner provisioning role
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          mask-aws-account-id: true
+          role-session-name: cyberful-runtime-${{ github.run_id }}
+          role-to-assume: ${{ vars.AWS_RUNNER_ROLE_ARN }}
+      - name: Replace stale capacity and start exactly two native runners
+        env:
+          AMD64_TEMPLATE_ID: ${{ vars.AWS_RUNNER_AMD64_TEMPLATE_ID }}
+          ARM64_TEMPLATE_ID: ${{ vars.AWS_RUNNER_ARM64_TEMPLATE_ID }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          parameter_root="/cyberful/github-runners/$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"
+          instance_ids=()
+
+          delete_parameters() {
+            for architecture in amd64 arm64; do
+              aws ssm delete-parameter \
+                --name "$parameter_root/$architecture" \
+                --region "$AWS_REGION" >/dev/null 2>&1 || true
+            done
+          }
+
+          terminate_instances() {
+            local ids
+            local -a stale_ids
+            ids="$(aws ec2 describe-instances \
+              --region "$AWS_REGION" \
+              --filters \
+                'Name=tag:cyberful:managed,Values=true' \
+                "Name=tag:cyberful:repository,Values=$GITHUB_REPOSITORY" \
+                'Name=instance-state-name,Values=pending,running,stopping,stopped' \
+              --query 'Reservations[].Instances[].InstanceId' \
+              --output text)"
+            if [[ -n "$ids" ]]; then
+              read -r -a stale_ids <<<"$ids"
+              aws ec2 terminate-instances \
+                --region "$AWS_REGION" \
+                --instance-ids "${stale_ids[@]}" >/dev/null
+              aws ec2 wait instance-terminated \
+                --region "$AWS_REGION" \
+                --instance-ids "${stale_ids[@]}"
+            fi
+          }
+
+          cleanup_on_failure() {
+            local status=$?
+            trap - EXIT
+            if (( status != 0 )); then
+              terminate_instances || true
+              delete_parameters
+            fi
+            exit "$status"
+          }
+          trap cleanup_on_failure EXIT
+
+          # Global workflow concurrency makes every matching instance stale.
+          # Reaping first also recovers safely after a cancelled or failed run.
+          terminate_instances
+          delete_parameters
+
+          for architecture in amd64 arm64; do
+            if [[ "$architecture" == amd64 ]]; then
+              template_id="$AMD64_TEMPLATE_ID"
+            else
+              template_id="$ARM64_TEMPLATE_ID"
+            fi
+            [[ "$template_id" =~ ^lt-[0-9a-f]+$ ]]
+
+            registration_token="$(gh api \
+              --method POST \
+              -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "repos/$GITHUB_REPOSITORY/actions/runners/registration-token" \
+              --jq .token)"
+            test -n "$registration_token"
+            echo "::add-mask::$registration_token"
+            aws ssm put-parameter \
+              --region "$AWS_REGION" \
+              --name "$parameter_root/$architecture" \
+              --type SecureString \
+              --value "$registration_token" \
+              --overwrite >/dev/null
+            unset registration_token
+
+            tag_specification="$(jq --compact-output --null-input \
+              --arg repository "$GITHUB_REPOSITORY" \
+              --arg run_id "$GITHUB_RUN_ID" \
+              --arg run_attempt "$GITHUB_RUN_ATTEMPT" \
+              '[{ResourceType:"instance",Tags:[
+                {Key:"cyberful:managed",Value:"true"},
+                {Key:"cyberful:repository",Value:$repository},
+                {Key:"cyberful:run-id",Value:$run_id},
+                {Key:"cyberful:run-attempt",Value:$run_attempt}
+              ]}]')"
+            instance_id="$(aws ec2 run-instances \
+              --region "$AWS_REGION" \
+              --launch-template "LaunchTemplateId=$template_id,Version=\$Default" \
+              --tag-specifications "$tag_specification" \
+              --count 1 \
+              --query 'Instances[0].InstanceId' \
+              --output text)"
+            [[ "$instance_id" =~ ^i-[0-9a-f]+$ ]]
+            instance_ids+=("$instance_id")
+          done
+
+          aws ec2 wait instance-status-ok \
+            --region "$AWS_REGION" \
+            --instance-ids "${instance_ids[@]}"
+
+          for architecture in amd64 arm64; do
+            runner_name="cyberful-aws-$architecture-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+            online=false
+            for _ in {1..60}; do
+              if gh api \
+                -H 'X-GitHub-Api-Version: 2026-03-10' \
+                --paginate "repos/$GITHUB_REPOSITORY/actions/runners?per_page=100" \
+                | jq --exit-status --arg name "$runner_name" \
+                    '.runners[] | select(.name == $name and .status == "online" and .busy == false)' \
+                    >/dev/null; then
+                online=true
+                break
+              fi
+              sleep 10
+            done
+            if [[ "$online" != true ]]; then
+              echo "Runner $runner_name did not become ready within ten minutes." >&2
+              exit 1
+            fi
+          done
 
   native-check:
     name: Native check ${{ matrix.platform }}
-    needs: [prepare]
-    if: github.event_name == 'pull_request' || needs.prepare.outputs.publish_main == 'false'
+    needs: [prepare, provision-runners]
+    if: needs.prepare.outputs.needs_runners == 'true' && needs.prepare.outputs.publish_main == 'false'
     runs-on: [self-hosted, linux, cyberful-container, "${{ matrix.arch }}"]
     timeout-minutes: 180
     env:
@@ -158,6 +329,8 @@ jobs:
             --tag "cyberful-os:check-${GITHUB_SHA}-${RUNTIME_ARCH}" \
             --build-arg "BUILD_VERSION=check-${GITHUB_SHA}" \
             --build-arg "BUILD_REVISION=${GITHUB_SHA}" \
+            --cache-from "type=gha,scope=cyberful-os-${RUNTIME_ARCH}" \
+            --cache-to "type=gha,mode=max,scope=cyberful-os-${RUNTIME_ARCH},ignore-error=true" \
             --load mcps
       - name: Verify architecture and full runtime behavior
         env:
@@ -181,7 +354,7 @@ jobs:
 
   main-native:
     name: Main native ${{ matrix.platform }}
-    needs: [prepare]
+    needs: [prepare, provision-runners]
     if: needs.prepare.outputs.publish_main == 'true' && needs.prepare.outputs.full_build == 'true' && needs.prepare.outputs.sha_exists == 'false'
     permissions:
       contents: read
@@ -242,6 +415,8 @@ jobs:
           outputs: type=image,name=${{ env.RUNTIME_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           provenance: mode=max
           sbom: true
+          cache-from: type=gha,scope=cyberful-os-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=cyberful-os-${{ matrix.arch }},ignore-error=true
           build-args: |
             BUILD_VERSION=sha-${{ github.sha }}
             BUILD_REVISION=${{ github.sha }}
@@ -531,7 +706,7 @@ jobs:
   required:
     name: Unified runtime required
     if: always()
-    needs: [prepare, native-check, main-native, main-index, main-copy, main-existing]
+    needs: [prepare, provision-runners, native-check, main-native, main-index, main-copy, main-existing]
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -541,7 +716,9 @@ jobs:
           PREPARE_RESULT: ${{ needs.prepare.result }}
           PUBLISH_MAIN: ${{ needs.prepare.outputs.publish_main }}
           FULL_BUILD: ${{ needs.prepare.outputs.full_build }}
+          NEEDS_RUNNERS: ${{ needs.prepare.outputs.needs_runners }}
           SHA_EXISTS: ${{ needs.prepare.outputs.sha_exists }}
+          PROVISION_RESULT: ${{ needs.provision-runners.result }}
           NATIVE_RESULT: ${{ needs.native-check.result }}
           MAIN_NATIVE_RESULT: ${{ needs.main-native.result }}
           INDEX_RESULT: ${{ needs.main-index.result }}
@@ -551,10 +728,17 @@ jobs:
         run: |
           test "$PREPARE_RESULT" = success
           if [[ "$PUBLISH_MAIN" != true ]]; then
-            test "$NATIVE_RESULT" = success
+            if [[ "$NEEDS_RUNNERS" == true ]]; then
+              test "$PROVISION_RESULT" = success
+              test "$NATIVE_RESULT" = success
+            else
+              test "$PROVISION_RESULT" = skipped
+              test "$NATIVE_RESULT" = skipped
+            fi
           elif [[ "$SHA_EXISTS" == true ]]; then
             test "$EXISTING_RESULT" = success
           elif [[ "$FULL_BUILD" == true ]]; then
+            test "$PROVISION_RESULT" = success
             test "$MAIN_NATIVE_RESULT" = success
             test "$INDEX_RESULT" = success
           else

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -216,6 +216,36 @@ jobs:
           }
           trap cleanup_on_failure EXIT
 
+          launch_instance() {
+            local template_id="$1"
+            shift
+            local error_file instance_type launched_id
+            error_file="$(mktemp)"
+            for instance_type in "$@"; do
+              if launched_id="$(aws ec2 run-instances \
+                --region "$AWS_REGION" \
+                --launch-template "LaunchTemplateId=$template_id,Version=\$Latest" \
+                --instance-type "$instance_type" \
+                --tag-specifications "$tag_specification" \
+                --count 1 \
+                --query 'Instances[0].InstanceId' \
+                --output text 2>"$error_file")"; then
+                rm -f "$error_file"
+                printf '%s\n' "$launched_id"
+                return 0
+              fi
+              if ! grep --quiet 'InsufficientInstanceCapacity' "$error_file"; then
+                cat "$error_file" >&2
+                rm -f "$error_file"
+                return 1
+              fi
+              echo "::warning::AWS has no $instance_type capacity in the approved subnet; trying the next native 4-vCPU family." >&2
+            done
+            cat "$error_file" >&2
+            rm -f "$error_file"
+            return 1
+          }
+
           # Global workflow concurrency makes every matching instance stale.
           # Reaping first also recovers safely after a cancelled or failed run.
           terminate_instances
@@ -224,8 +254,10 @@ jobs:
           for architecture in amd64 arm64; do
             if [[ "$architecture" == amd64 ]]; then
               template_id="$AMD64_TEMPLATE_ID"
+              instance_types=(c7i.xlarge c6i.xlarge m7i.xlarge m6i.xlarge)
             else
               template_id="$ARM64_TEMPLATE_ID"
+              instance_types=(c7g.xlarge c6g.xlarge m7g.xlarge m6g.xlarge)
             fi
             [[ "$template_id" =~ ^lt-[0-9a-f]+$ ]]
 
@@ -254,13 +286,7 @@ jobs:
                 {Key:"cyberful:run-id",Value:$run_id},
                 {Key:"cyberful:run-attempt",Value:$run_attempt}
               ]}]')"
-            instance_id="$(aws ec2 run-instances \
-              --region "$AWS_REGION" \
-              --launch-template "LaunchTemplateId=$template_id,Version=\$Latest" \
-              --tag-specifications "$tag_specification" \
-              --count 1 \
-              --query 'Instances[0].InstanceId' \
-              --output text)"
+            instance_id="$(launch_instance "$template_id" "${instance_types[@]}")"
             [[ "$instance_id" =~ ^i-[0-9a-f]+$ ]]
             instance_ids+=("$instance_id")
           done

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -241,7 +241,7 @@ jobs:
               ]}]')"
             instance_id="$(aws ec2 run-instances \
               --region "$AWS_REGION" \
-              --launch-template "LaunchTemplateId=$template_id,Version=\$Default" \
+              --launch-template "LaunchTemplateId=$template_id,Version=\$Latest" \
               --tag-specifications "$tag_specification" \
               --count 1 \
               --query 'Instances[0].InstanceId' \

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -372,7 +372,7 @@ jobs:
             BUILD_VERSION=check-${{ github.sha }}
             BUILD_REVISION=${{ github.sha }}
           cache-from: type=gha,scope=cyberful-os-${{ env.RUNTIME_ARCH }}
-          cache-to: type=gha,mode=max,scope=cyberful-os-${{ env.RUNTIME_ARCH }},ignore-error=true
+          cache-to: type=gha,mode=min,scope=cyberful-os-${{ env.RUNTIME_ARCH }},ignore-error=true
           load: true
       - name: Verify architecture and full runtime behavior
         env:
@@ -458,7 +458,7 @@ jobs:
           provenance: mode=max
           sbom: true
           cache-from: type=gha,scope=cyberful-os-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=cyberful-os-${{ matrix.arch }},ignore-error=true
+          cache-to: type=gha,mode=min,scope=cyberful-os-${{ matrix.arch }},ignore-error=true
           build-args: |
             BUILD_VERSION=sha-${{ github.sha }}
             BUILD_REVISION=${{ github.sha }}

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -336,17 +336,18 @@ jobs:
           CYBER_BROWSER_BROWSERS_PATH: ${{ runner.temp }}/cyberful-browser
         run: npm --prefix mcps run browser:install -- --with-deps
       - name: Build the native image into Docker
-        shell: bash
-        run: |
-          docker buildx build \
-            --platform "$RUNTIME_PLATFORM" \
-            --file mcps/cyberful-os/Dockerfile \
-            --tag "cyberful-os:check-${GITHUB_SHA}-${RUNTIME_ARCH}" \
-            --build-arg "BUILD_VERSION=check-${GITHUB_SHA}" \
-            --build-arg "BUILD_REVISION=${GITHUB_SHA}" \
-            --cache-from "type=gha,scope=cyberful-os-${RUNTIME_ARCH}" \
-            --cache-to "type=gha,mode=max,scope=cyberful-os-${RUNTIME_ARCH},ignore-error=true" \
-            --load mcps
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: mcps
+          file: mcps/cyberful-os/Dockerfile
+          platforms: ${{ env.RUNTIME_PLATFORM }}
+          tags: cyberful-os:check-${{ github.sha }}-${{ env.RUNTIME_ARCH }}
+          build-args: |
+            BUILD_VERSION=check-${{ github.sha }}
+            BUILD_REVISION=${{ github.sha }}
+          cache-from: type=gha,scope=cyberful-os-${{ env.RUNTIME_ARCH }}
+          cache-to: type=gha,mode=max,scope=cyberful-os-${{ env.RUNTIME_ARCH }},ignore-error=true
+          load: true
       - name: Verify architecture and full runtime behavior
         env:
           CYBER_BROWSER_BROWSERS_PATH: ${{ runner.temp }}/cyberful-browser

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -168,6 +168,20 @@ jobs:
             done
           }
 
+          dump_console_output() {
+            local instance_id
+            for instance_id in "${instance_ids[@]}"; do
+              echo "::group::EC2 console output for $instance_id"
+              aws ec2 get-console-output \
+                --region "$AWS_REGION" \
+                --instance-id "$instance_id" \
+                --latest \
+                --query Output \
+                --output text || true
+              echo "::endgroup::"
+            done
+          }
+
           terminate_instances() {
             local ids
             local -a stale_ids
@@ -194,6 +208,7 @@ jobs:
             local status=$?
             trap - EXIT
             if (( status != 0 )); then
+              dump_console_output
               terminate_instances || true
               delete_parameters
             fi

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -157,18 +157,20 @@ Do not substitute another public launcher name: it would break the documented
 
 ## GitHub release prerequisites
 
-- Keep `main` as the default protected branch and require both
-  **Typecheck, test, and docs** and **Unified runtime required** before merging.
+- Keep `main` as the default protected branch and require one current approval,
+  dismiss stale approvals after every new push, and require both **Typecheck,
+  test, and docs** and **Unified runtime required** before merging.
   Require `main` to advance by one
   first-parent commit per push (squash or a single merge commit; no rebase
   merges or direct multi-commit pushes), because GitHub emits one workflow SHA
   per push. The runtime workflow queues up to 100 `main` runs and processes
   registry mutations one at a time.
-- Register exactly two self-hosted runner classes with the labels documented in
-  the testing guide. Do not install or register QEMU/binfmt emulators on them.
-  Keep the runner agent current and provision these as ephemeral, clean hosts:
-  pull requests execute repository code and use the Docker socket, so a
-  persistent PR runner must never later become a trusted `main` publisher.
+- Deploy the two launch templates and OIDC roles from
+  `infra/github-runners.yml`, then configure the protected GitHub environments
+  documented in the testing guide. Do not install or register QEMU/binfmt
+  emulators. Pull requests execute repository code and use the Docker socket,
+  so every runner is single-job, ephemeral, and destroyed before another trust
+  context can use it.
 - Allow GitHub Actions to write repository packages. The runtime assembly job
   and interrupted-signature recovery receive `packages: write` plus
   `id-token: write` for Cosign; runtime platform jobs and tag-copy jobs receive

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -70,7 +70,9 @@ Deploy `infra/github-runners.yml` once in `eu-central-1`, selecting a public
 subnet in the configured VPC. The subnet is part of both launch templates so
 the provisioning role can require every network resource to originate from an
 approved template; it must assign public IPv4 addresses and route outbound
-traffic through an internet gateway. Record the stack's three outputs as the
+traffic through an internet gateway. Provisioning always consumes the latest
+CloudFormation-managed template version; the GitHub role cannot create or
+modify versions. Record the stack's three outputs as the
 `AWS_RUNNER_ROLE_ARN`, `AWS_RUNNER_AMD64_TEMPLATE_ID`, and
 `AWS_RUNNER_ARM64_TEMPLATE_ID` variables in both GitHub environments:
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -31,27 +31,62 @@ default Bun tier because restricted sandboxes may forbid binding a loopback
 socket.
 
 GitHub CI runs `make typecheck test-bun test-python` and the strict documentation
-build for every pull request and push to `main`. Every pull request also builds
-and tests `linux/amd64` and `linux/arm64` concurrently on dedicated native
-self-hosted runners; a manual `runtime.yml` run outside `main` has the same
-non-publishing behavior. Pull requests and non-main manual runs upload logs
-only. Main builds and pushes each native platform with BuildKit SBOM and
-provenance, pulls and tests that exact published digest, assembles one OCI
-index, and signs its digest through GitHub OIDC. No QEMU is installed or used.
+build for every pull request and push to `main`. A runtime-affecting pull request
+stops at the protected `runtime-pr` environment until the repository owner
+chooses **Review deployments** and approves that exact run. Approval creates
+one ephemeral `linux/amd64` and one ephemeral `linux/arm64` EC2 runner; rejected
+or unreviewed runs consume no EC2 capacity. A manual `runtime.yml` run outside
+`main` has the same reviewed, non-publishing behavior. Pull requests and
+non-main manual runs upload logs only. Main builds and pushes each native
+platform with BuildKit SBOM and provenance, pulls and tests that exact published
+digest, assembles one OCI index, and signs its digest through GitHub OIDC. No
+QEMU is installed or used.
 
-Main runtime runs use the `runtime-main` FIFO concurrency queue. The OCI index
-stores its source commit, and the next run compares from that revision so a
-failed publication cannot make a later non-runtime commit copy a stale image.
+All runtime runs share the `runtime-native` FIFO concurrency queue, so AWS can
+never run more than the dedicated amd64/arm64 pair for this repository. The
+OCI index stores its source commit, and the next run compares from that
+revision so a failed publication cannot make a later non-runtime commit copy a
+stale image.
 When no runtime boundary changed, the workflow verifies `edge` and its Cosign
 signature before copying the same digest registry-side to the new `sha-*` tag.
 Before moving `edge`, a build also checks that its commit is still the live head
 of `main`, so an older queued run cannot regress the tag.
 
-Each runtime runner needs the labels `self-hosted`, `linux`,
+Each runtime runner receives the labels `self-hosted`, `linux`,
 `cyberful-container`, and its architecture (`amd64` or `arm64`), plus at least
 100 GB free, Docker BuildKit/buildx, Bun, npm, Python, a C compiler, and
 passwordless `sudo` for the pinned browser's Linux packages. The workflow
 installs the pinned Patchright Chromium and its host libraries before the live
 proxy tests; system Chrome is exercised when the runner already provides it.
-The workflow does not import persistent BuildKit or Bun caches into publishable
-builds; per-job BuildKit state is pruned to an 80 GB bound and then cleaned up.
+BuildKit exports an architecture-scoped cache to GitHub Actions and restores it
+on later runs, so disposable instances still reuse safe Docker layers. The
+publishable image remains a fresh, digest-addressed result; local BuildKit state
+is pruned to an 80 GB bound and the encrypted root volume is deleted with the
+instance.
+
+## Ephemeral runner control plane
+
+Deploy `infra/github-runners.yml` once in `eu-central-1`. Record its three
+outputs as the `AWS_RUNNER_ROLE_ARN`, `AWS_RUNNER_AMD64_TEMPLATE_ID`, and
+`AWS_RUNNER_ARM64_TEMPLATE_ID` variables in both GitHub environments:
+
+- `runtime-pr` requires `ottaviofogliata` as its only reviewer and permits
+  self-review, because GitHub does not allow a pull-request author to approve
+  their own PR review.
+- `runtime-main` has no required reviewer and permits deployments only from
+  `main`; cleanup and trusted main publication use it automatically.
+
+Install a repository-scoped GitHub App with repository Administration write
+permission, used only to mint the one-hour runner registration token. Store its
+numeric app ID as `CYBERFUL_RUNNER_APP_ID` and its private key as the
+`CYBERFUL_RUNNER_APP_PRIVATE_KEY` environment secret in both environments.
+Never store either the registration token or AWS credentials in repository
+secrets. The private key is available only after the environment policy admits
+the job; AWS credentials come from GitHub OIDC and expire with the job.
+
+The provisioning job writes each one-time registration token to an encrypted
+SSM parameter. The matching EC2 instance consumes and deletes it before running
+any pull-request code. The instance has no inbound security-group rules,
+requires IMDSv2 with a hop limit of one, terminates after its single ephemeral
+job, and has a four-hour shutdown deadline. The trusted cleanup workflow on
+`main` handles cancellation and an hourly stale-capacity sweep.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -98,4 +98,6 @@ job, and has a four-hour shutdown deadline. A failed bootstrap remains alive
 only long enough for the provisioning job to copy its serial-console output
 into the private Actions log, then the same failure trap terminates it. The
 trusted cleanup workflow on `main` handles cancellation and an hourly
-stale-capacity sweep.
+stale-capacity sweep. Both the GitHub Actions runner and the official AWS CLI
+v2 installer are version-pinned and checksum-verified independently for amd64
+and arm64 before execution.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -72,7 +72,10 @@ the provisioning role can require every network resource to originate from an
 approved template; it must assign public IPv4 addresses and route outbound
 traffic through an internet gateway. Provisioning always consumes the latest
 CloudFormation-managed template version; the GitHub role cannot create or
-modify versions. Record the stack's three outputs as the
+modify versions. A temporary capacity shortage retries a bounded list of native
+4-vCPU compute and general-purpose families in the same approved subnet. Other
+EC2 failures remain fatal, and exhausting the list terminates any peer runner
+that was already created. Record the stack's three outputs as the
 `AWS_RUNNER_ROLE_ARN`, `AWS_RUNNER_AMD64_TEMPLATE_ID`, and
 `AWS_RUNNER_ARM64_TEMPLATE_ID` variables in both GitHub environments:
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -66,8 +66,12 @@ instance.
 
 ## Ephemeral runner control plane
 
-Deploy `infra/github-runners.yml` once in `eu-central-1`. Record its three
-outputs as the `AWS_RUNNER_ROLE_ARN`, `AWS_RUNNER_AMD64_TEMPLATE_ID`, and
+Deploy `infra/github-runners.yml` once in `eu-central-1`, selecting a public
+subnet in the configured VPC. The subnet is part of both launch templates so
+the provisioning role can require every network resource to originate from an
+approved template; it must assign public IPv4 addresses and route outbound
+traffic through an internet gateway. Record the stack's three outputs as the
+`AWS_RUNNER_ROLE_ARN`, `AWS_RUNNER_AMD64_TEMPLATE_ID`, and
 `AWS_RUNNER_ARM64_TEMPLATE_ID` variables in both GitHub environments:
 
 - `runtime-pr` requires `ottaviofogliata` as its only reviewer and permits

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -58,12 +58,13 @@ Each runtime runner receives the labels `self-hosted`, `linux`,
 passwordless `sudo` for the pinned browser's Linux packages. The workflow
 installs the pinned Patchright Chromium and its host libraries before the live
 proxy tests; system Chrome is exercised when the runner already provides it.
-BuildKit exports the final-image layers to an architecture-scoped GitHub
-Actions cache and restores them on later runs, so disposable instances still
-reuse safe Docker layers without duplicating intermediate stages into the
-repository's bounded cache quota. The publishable image remains a fresh,
-digest-addressed result; local BuildKit state is pruned to an 80 GB bound and
-the encrypted root volume is deleted with the instance.
+On `main`, BuildKit exports the final-image layers to an architecture-scoped
+GitHub Actions cache. Pull requests and non-main dry-runs restore the base
+branch cache read-only, so disposable instances reuse safe Docker layers
+without duplicating a complete image cache for every pull-request ref or
+retaining quota-heavy intermediate stages. The publishable image remains a
+fresh, digest-addressed result; local BuildKit state is pruned to an 80 GB
+bound and the encrypted root volume is deleted with the instance.
 
 ## Ephemeral runner control plane
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -58,11 +58,12 @@ Each runtime runner receives the labels `self-hosted`, `linux`,
 passwordless `sudo` for the pinned browser's Linux packages. The workflow
 installs the pinned Patchright Chromium and its host libraries before the live
 proxy tests; system Chrome is exercised when the runner already provides it.
-BuildKit exports an architecture-scoped cache to GitHub Actions and restores it
-on later runs, so disposable instances still reuse safe Docker layers. The
-publishable image remains a fresh, digest-addressed result; local BuildKit state
-is pruned to an 80 GB bound and the encrypted root volume is deleted with the
-instance.
+BuildKit exports the final-image layers to an architecture-scoped GitHub
+Actions cache and restores them on later runs, so disposable instances still
+reuse safe Docker layers without duplicating intermediate stages into the
+repository's bounded cache quota. The publishable image remains a fresh,
+digest-addressed result; local BuildKit state is pruned to an 80 GB bound and
+the encrypted root volume is deleted with the instance.
 
 ## Ephemeral runner control plane
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -94,5 +94,8 @@ The provisioning job writes each one-time registration token to an encrypted
 SSM parameter. The matching EC2 instance consumes and deletes it before running
 any pull-request code. The instance has no inbound security-group rules,
 requires IMDSv2 with a hop limit of one, terminates after its single ephemeral
-job, and has a four-hour shutdown deadline. The trusted cleanup workflow on
-`main` handles cancellation and an hourly stale-capacity sweep.
+job, and has a four-hour shutdown deadline. A failed bootstrap remains alive
+only long enough for the provisioning job to copy its serial-console output
+into the private Actions log, then the same failure trap terminates it. The
+trusted cleanup workflow on `main` handles cancellation and an hourly
+stale-capacity sweep.

--- a/infra/github-runners.yml
+++ b/infra/github-runners.yml
@@ -161,7 +161,19 @@ Resources:
                 #!/usr/bin/env bash
                 set -Eeuo pipefail
                 shutdown -h +240
-                trap 'shutdown -h now' EXIT
+                exec > >(tee -a /var/log/cyberful-runner-bootstrap.log \
+                  | logger --tag cyberful-runner-bootstrap --stderr 2>/dev/console) 2>&1
+                cleanup() {
+                  status=$?
+                  trap - EXIT
+                  if (( status != 0 )); then
+                    echo "Cyberful runner bootstrap failed with exit status $status."
+                    sleep 900
+                  fi
+                  shutdown -h now
+                  exit "$status"
+                }
+                trap cleanup EXIT
 
                 export DEBIAN_FRONTEND=noninteractive
                 apt-get update
@@ -273,7 +285,19 @@ Resources:
                 #!/usr/bin/env bash
                 set -Eeuo pipefail
                 shutdown -h +240
-                trap 'shutdown -h now' EXIT
+                exec > >(tee -a /var/log/cyberful-runner-bootstrap.log \
+                  | logger --tag cyberful-runner-bootstrap --stderr 2>/dev/console) 2>&1
+                cleanup() {
+                  status=$?
+                  trap - EXIT
+                  if (( status != 0 )); then
+                    echo "Cyberful runner bootstrap failed with exit status $status."
+                    sleep 900
+                  fi
+                  shutdown -h now
+                  exit "$status"
+                }
+                trap cleanup EXIT
 
                 export DEBIAN_FRONTEND=noninteractive
                 apt-get update
@@ -394,6 +418,14 @@ Resources:
                   - ec2:DescribeInstanceStatus
                   - ec2:DescribeLaunchTemplates
                 Resource: "*"
+              - Sid: InspectManagedRunnerBootstrap
+                Effect: Allow
+                Action: ec2:GetConsoleOutput
+                Resource: !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*
+                Condition:
+                  StringEquals:
+                    aws:ResourceTag/cyberful:managed: "true"
+                    aws:ResourceTag/cyberful:repository: !Ref Repository
               - Sid: PassOnlyTheEphemeralRunnerRoleToEc2
                 Effect: Allow
                 Action: iam:PassRole

--- a/infra/github-runners.yml
+++ b/infra/github-runners.yml
@@ -16,6 +16,9 @@ Parameters:
   VpcId:
     Type: AWS::EC2::VPC::Id
     Description: VPC with default subnets that provide outbound internet access
+  SubnetId:
+    Type: AWS::EC2::Subnet::Id
+    Description: Public subnet in VpcId used by both ephemeral runner launch templates
   Amd64InstanceType:
     Type: String
     Default: c7i.xlarge
@@ -126,6 +129,7 @@ Resources:
           - AssociatePublicIpAddress: true
             DeleteOnTermination: true
             DeviceIndex: 0
+            SubnetId: !Ref SubnetId
             Groups:
               - !GetAtt RunnerSecurityGroup.GroupId
         BlockDeviceMappings:
@@ -237,6 +241,7 @@ Resources:
           - AssociatePublicIpAddress: true
             DeleteOnTermination: true
             DeviceIndex: 0
+            SubnetId: !Ref SubnetId
             Groups:
               - !GetAtt RunnerSecurityGroup.GroupId
         BlockDeviceMappings:

--- a/infra/github-runners.yml
+++ b/infra/github-runners.yml
@@ -1,0 +1,412 @@
+# ── Ephemeral Native GitHub Runners ──────────────────────────────
+# Defines the least-privilege AWS boundary and the two native EC2 launch
+#   templates used only after a protected GitHub environment is approved.
+# → .github/workflows/runtime.yml — provisions one runner per architecture.
+# → .github/workflows/runtime-runner-cleanup.yml — removes stranded capacity.
+# @docs/development/testing.md
+# ─────────────────────────────────────────────────────────────────
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Ephemeral native EC2 runners for the Cyberful unified runtime
+
+Parameters:
+  Repository:
+    Type: String
+    Default: cyberful/cyberful
+    AllowedPattern: "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: VPC with default subnets that provide outbound internet access
+  Amd64InstanceType:
+    Type: String
+    Default: c7i.xlarge
+  Arm64InstanceType:
+    Type: String
+    Default: c7g.xlarge
+  RootVolumeSize:
+    Type: Number
+    Default: 160
+    MinValue: 120
+  RunnerVersion:
+    Type: String
+    Default: 2.336.0
+    AllowedPattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+  RunnerX64Sha256:
+    Type: String
+    Default: 04cf0be1aff4c3ec3554466c39124ca250e3effd8873bb7e8d68535aa9505d5d
+    AllowedPattern: "^[0-9a-f]{64}$"
+  RunnerArm64Sha256:
+    Type: String
+    Default: 58b758e420b87093fbd4bfddd368074960053e2f1388f01848c82624b90f27d1
+    AllowedPattern: "^[0-9a-f]{64}$"
+  Amd64ImageId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
+  Arm64ImageId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/canonical/ubuntu/server/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id
+
+Resources:
+  GitHubOidcProvider:
+    Type: AWS::IAM::OIDCProvider
+    Properties:
+      Url: https://token.actions.githubusercontent.com
+      ClientIdList:
+        - sts.amazonaws.com
+      Tags:
+        - Key: cyberful:managed
+          Value: "true"
+
+  RunnerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Outbound-only network access for ephemeral GitHub runners
+      VpcId: !Ref VpcId
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Name
+          Value: cyberful-github-runners
+        - Key: cyberful:managed
+          Value: "true"
+
+  RunnerInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: CyberfulGitHubRunnerInstance
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: ConsumeOneTimeRegistrationToken
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:DeleteParameter
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/cyberful/github-runners/*
+      Tags:
+        - Key: cyberful:managed
+          Value: "true"
+
+  RunnerInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+        - !Ref RunnerInstanceRole
+
+  Amd64LaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateName: cyberful-github-runner-amd64
+      TagSpecifications:
+        - ResourceType: launch-template
+          Tags:
+            - Key: cyberful:managed
+              Value: "true"
+      LaunchTemplateData:
+        ImageId: !Ref Amd64ImageId
+        InstanceType: !Ref Amd64InstanceType
+        InstanceInitiatedShutdownBehavior: terminate
+        IamInstanceProfile:
+          Arn: !GetAtt RunnerInstanceProfile.Arn
+        MetadataOptions:
+          HttpEndpoint: enabled
+          HttpProtocolIpv6: disabled
+          HttpPutResponseHopLimit: 1
+          HttpTokens: required
+          InstanceMetadataTags: enabled
+        NetworkInterfaces:
+          - AssociatePublicIpAddress: true
+            DeleteOnTermination: true
+            DeviceIndex: 0
+            Groups:
+              - !GetAtt RunnerSecurityGroup.GroupId
+        BlockDeviceMappings:
+          - DeviceName: /dev/sda1
+            Ebs:
+              DeleteOnTermination: true
+              Encrypted: true
+              VolumeSize: !Ref RootVolumeSize
+              VolumeType: gp3
+        TagSpecifications:
+          - ResourceType: instance
+            Tags:
+              - Key: Name
+                Value: cyberful-github-runner-amd64
+              - Key: cyberful:architecture
+                Value: amd64
+          - ResourceType: volume
+            Tags:
+              - Key: cyberful:architecture
+                Value: amd64
+              - Key: cyberful:managed
+                Value: "true"
+              - Key: cyberful:repository
+                Value: !Ref Repository
+        UserData:
+          Fn::Base64:
+            Fn::Sub:
+              - |
+                #!/usr/bin/env bash
+                set -Eeuo pipefail
+                shutdown -h +240
+                trap 'shutdown -h now' EXIT
+
+                export DEBIAN_FRONTEND=noninteractive
+                apt-get update
+                apt-get install --yes --no-install-recommends \
+                  awscli build-essential ca-certificates curl docker-buildx docker.io \
+                  git jq npm python3 python3-pip python3-venv sudo tar unzip
+                systemctl enable --now docker
+
+                id runner >/dev/null 2>&1 || useradd --create-home --shell /bin/bash runner
+                usermod --append --groups docker runner
+                printf 'runner ALL=(ALL) NOPASSWD:ALL\n' >/etc/sudoers.d/cyberful-runner
+                chmod 0440 /etc/sudoers.d/cyberful-runner
+
+                install --directory --owner runner --group runner /opt/actions-runner
+                archive=/tmp/actions-runner.tar.gz
+                curl --fail --location --retry 5 --retry-all-errors \
+                  --output "$archive" \
+                  "https://github.com/actions/runner/releases/download/v${RunnerVersion}/actions-runner-linux-${RunnerArch}-${RunnerVersion}.tar.gz"
+                printf '%s  %s\n' '${RunnerSha256}' "$archive" | sha256sum --check --strict
+                tar --extract --gzip --file "$archive" --directory /opt/actions-runner
+                /opt/actions-runner/bin/installdependencies.sh
+                chown --recursive runner:runner /opt/actions-runner
+
+                metadata_token="$(curl --fail --silent --show-error --request PUT \
+                  --header 'X-aws-ec2-metadata-token-ttl-seconds: 21600' \
+                  http://169.254.169.254/latest/api/token)"
+                metadata() {
+                  curl --fail --silent --show-error \
+                    --header "X-aws-ec2-metadata-token: $metadata_token" \
+                    "http://169.254.169.254/latest/meta-data/$1"
+                }
+                run_id="$(metadata 'tags/instance/cyberful:run-id')"
+                run_attempt="$(metadata 'tags/instance/cyberful:run-attempt')"
+                architecture="$(metadata 'tags/instance/cyberful:architecture')"
+                parameter="/cyberful/github-runners/$run_id/$run_attempt/$architecture"
+                registration_token="$(aws ssm get-parameter \
+                  --name "$parameter" --with-decryption \
+                  --query 'Parameter.Value' --output text --region ${AWS::Region})"
+                aws ssm delete-parameter --name "$parameter" --region ${AWS::Region}
+
+                runner_name="cyberful-aws-$architecture-$run_id-$run_attempt"
+                cd /opt/actions-runner
+                sudo --user runner --set-home ./config.sh \
+                  --url 'https://github.com/${Repository}' \
+                  --token "$registration_token" \
+                  --name "$runner_name" \
+                  --labels "cyberful-container,$architecture" \
+                  --work _work \
+                  --unattended --ephemeral --replace
+                unset registration_token
+                sudo --user runner --set-home ./run.sh
+              - RunnerArch: x64
+                RunnerSha256: !Ref RunnerX64Sha256
+
+  Arm64LaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateName: cyberful-github-runner-arm64
+      TagSpecifications:
+        - ResourceType: launch-template
+          Tags:
+            - Key: cyberful:managed
+              Value: "true"
+      LaunchTemplateData:
+        ImageId: !Ref Arm64ImageId
+        InstanceType: !Ref Arm64InstanceType
+        InstanceInitiatedShutdownBehavior: terminate
+        IamInstanceProfile:
+          Arn: !GetAtt RunnerInstanceProfile.Arn
+        MetadataOptions:
+          HttpEndpoint: enabled
+          HttpProtocolIpv6: disabled
+          HttpPutResponseHopLimit: 1
+          HttpTokens: required
+          InstanceMetadataTags: enabled
+        NetworkInterfaces:
+          - AssociatePublicIpAddress: true
+            DeleteOnTermination: true
+            DeviceIndex: 0
+            Groups:
+              - !GetAtt RunnerSecurityGroup.GroupId
+        BlockDeviceMappings:
+          - DeviceName: /dev/sda1
+            Ebs:
+              DeleteOnTermination: true
+              Encrypted: true
+              VolumeSize: !Ref RootVolumeSize
+              VolumeType: gp3
+        TagSpecifications:
+          - ResourceType: instance
+            Tags:
+              - Key: Name
+                Value: cyberful-github-runner-arm64
+              - Key: cyberful:architecture
+                Value: arm64
+          - ResourceType: volume
+            Tags:
+              - Key: cyberful:architecture
+                Value: arm64
+              - Key: cyberful:managed
+                Value: "true"
+              - Key: cyberful:repository
+                Value: !Ref Repository
+        UserData:
+          Fn::Base64:
+            Fn::Sub:
+              - |
+                #!/usr/bin/env bash
+                set -Eeuo pipefail
+                shutdown -h +240
+                trap 'shutdown -h now' EXIT
+
+                export DEBIAN_FRONTEND=noninteractive
+                apt-get update
+                apt-get install --yes --no-install-recommends \
+                  awscli build-essential ca-certificates curl docker-buildx docker.io \
+                  git jq npm python3 python3-pip python3-venv sudo tar unzip
+                systemctl enable --now docker
+
+                id runner >/dev/null 2>&1 || useradd --create-home --shell /bin/bash runner
+                usermod --append --groups docker runner
+                printf 'runner ALL=(ALL) NOPASSWD:ALL\n' >/etc/sudoers.d/cyberful-runner
+                chmod 0440 /etc/sudoers.d/cyberful-runner
+
+                install --directory --owner runner --group runner /opt/actions-runner
+                archive=/tmp/actions-runner.tar.gz
+                curl --fail --location --retry 5 --retry-all-errors \
+                  --output "$archive" \
+                  "https://github.com/actions/runner/releases/download/v${RunnerVersion}/actions-runner-linux-${RunnerArch}-${RunnerVersion}.tar.gz"
+                printf '%s  %s\n' '${RunnerSha256}' "$archive" | sha256sum --check --strict
+                tar --extract --gzip --file "$archive" --directory /opt/actions-runner
+                /opt/actions-runner/bin/installdependencies.sh
+                chown --recursive runner:runner /opt/actions-runner
+
+                metadata_token="$(curl --fail --silent --show-error --request PUT \
+                  --header 'X-aws-ec2-metadata-token-ttl-seconds: 21600' \
+                  http://169.254.169.254/latest/api/token)"
+                metadata() {
+                  curl --fail --silent --show-error \
+                    --header "X-aws-ec2-metadata-token: $metadata_token" \
+                    "http://169.254.169.254/latest/meta-data/$1"
+                }
+                run_id="$(metadata 'tags/instance/cyberful:run-id')"
+                run_attempt="$(metadata 'tags/instance/cyberful:run-attempt')"
+                architecture="$(metadata 'tags/instance/cyberful:architecture')"
+                parameter="/cyberful/github-runners/$run_id/$run_attempt/$architecture"
+                registration_token="$(aws ssm get-parameter \
+                  --name "$parameter" --with-decryption \
+                  --query 'Parameter.Value' --output text --region ${AWS::Region})"
+                aws ssm delete-parameter --name "$parameter" --region ${AWS::Region}
+
+                runner_name="cyberful-aws-$architecture-$run_id-$run_attempt"
+                cd /opt/actions-runner
+                sudo --user runner --set-home ./config.sh \
+                  --url 'https://github.com/${Repository}' \
+                  --token "$registration_token" \
+                  --name "$runner_name" \
+                  --labels "cyberful-container,$architecture" \
+                  --work _work \
+                  --unattended --ephemeral --replace
+                unset registration_token
+                sudo --user runner --set-home ./run.sh
+              - RunnerArch: arm64
+                RunnerSha256: !Ref RunnerArm64Sha256
+
+  GitHubProvisionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: CyberfulGitHubRunnerProvision
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Ref GitHubOidcProvider
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+              StringLike:
+                token.actions.githubusercontent.com:sub:
+                  - !Sub repo:${Repository}:environment:runtime-pr
+                  - !Sub repo:${Repository}:environment:runtime-main
+      Policies:
+        - PolicyName: ProvisionAndReapEphemeralRunners
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: UseOnlyManagedLaunchTemplates
+                Effect: Allow
+                Action: ec2:RunInstances
+                NotResource: !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*
+                Condition:
+                  ArnLike:
+                    ec2:LaunchTemplate:
+                      - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/${Amd64LaunchTemplate}
+                      - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/${Arm64LaunchTemplate}
+                  Bool:
+                    ec2:IsLaunchTemplateResource: "true"
+              - Sid: AuthorizeManagedLaunchTemplates
+                Effect: Allow
+                Action: ec2:RunInstances
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/${Amd64LaunchTemplate}
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/${Arm64LaunchTemplate}
+              - Sid: TagNewRunnerInstances
+                Effect: Allow
+                Action: ec2:CreateTags
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:volume/*
+                Condition:
+                  StringEquals:
+                    ec2:CreateAction: RunInstances
+                    aws:RequestTag/cyberful:managed: "true"
+                    aws:RequestTag/cyberful:repository: !Ref Repository
+              - Sid: TerminateOnlyManagedRunners
+                Effect: Allow
+                Action: ec2:TerminateInstances
+                Resource: !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*
+                Condition:
+                  StringEquals:
+                    aws:ResourceTag/cyberful:managed: "true"
+                    aws:ResourceTag/cyberful:repository: !Ref Repository
+              - Sid: InspectRunnerCapacity
+                Effect: Allow
+                Action:
+                  - ec2:DescribeInstances
+                  - ec2:DescribeInstanceStatus
+                  - ec2:DescribeLaunchTemplates
+                Resource: "*"
+              - Sid: ManageOneTimeRegistrationTokens
+                Effect: Allow
+                Action:
+                  - ssm:DeleteParameter
+                  - ssm:DeleteParameters
+                  - ssm:GetParametersByPath
+                  - ssm:PutParameter
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/cyberful/github-runners/*
+      Tags:
+        - Key: cyberful:managed
+          Value: "true"
+
+Outputs:
+  ProvisionRoleArn:
+    Value: !GetAtt GitHubProvisionRole.Arn
+  Amd64LaunchTemplateId:
+    Value: !Ref Amd64LaunchTemplate
+  Arm64LaunchTemplateId:
+    Value: !Ref Arm64LaunchTemplate
+  Region:
+    Value: !Ref AWS::Region

--- a/infra/github-runners.yml
+++ b/infra/github-runners.yml
@@ -389,6 +389,13 @@ Resources:
                   - ec2:DescribeInstanceStatus
                   - ec2:DescribeLaunchTemplates
                 Resource: "*"
+              - Sid: PassOnlyTheEphemeralRunnerRoleToEc2
+                Effect: Allow
+                Action: iam:PassRole
+                Resource: !GetAtt RunnerInstanceRole.Arn
+                Condition:
+                  StringEquals:
+                    iam:PassedToService: ec2.amazonaws.com
               - Sid: ManageOneTimeRegistrationTokens
                 Effect: Allow
                 Action:

--- a/infra/github-runners.yml
+++ b/infra/github-runners.yml
@@ -41,6 +41,18 @@ Parameters:
     Type: String
     Default: 58b758e420b87093fbd4bfddd368074960053e2f1388f01848c82624b90f27d1
     AllowedPattern: "^[0-9a-f]{64}$"
+  AwsCliVersion:
+    Type: String
+    Default: 2.27.41
+    AllowedPattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+  AwsCliX64Sha256:
+    Type: String
+    Default: 15daae6cc803984064e3d4be9cfd07c4ae8ea703633c0a0b67acc6e321f706a3
+    AllowedPattern: "^[0-9a-f]{64}$"
+  AwsCliArm64Sha256:
+    Type: String
+    Default: 2c6ed21cf7cff0a7d77118c69bee867128bf4c588db7b5c044ffba5faeb6ccde
+    AllowedPattern: "^[0-9a-f]{64}$"
   Amd64ImageId:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: /aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
@@ -178,9 +190,23 @@ Resources:
                 export DEBIAN_FRONTEND=noninteractive
                 apt-get update
                 apt-get install --yes --no-install-recommends \
-                  awscli build-essential ca-certificates curl docker-buildx docker.io \
+                  build-essential ca-certificates curl docker-buildx docker.io \
                   git jq npm python3 python3-pip python3-venv sudo tar unzip
                 systemctl enable --now docker
+
+                aws_cli_archive=/tmp/awscliv2.zip
+                aws_cli_installer=/tmp/aws-cli-installer
+                curl --fail --location --retry 5 --retry-all-errors \
+                  --output "$aws_cli_archive" \
+                  "https://awscli.amazonaws.com/awscli-exe-linux-${AwsCliArch}-${AwsCliVersion}.zip"
+                printf '%s  %s\n' '${AwsCliSha256}' "$aws_cli_archive" \
+                  | sha256sum --check --strict
+                install --directory "$aws_cli_installer"
+                unzip -q "$aws_cli_archive" -d "$aws_cli_installer"
+                "$aws_cli_installer/aws/install" \
+                  --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli
+                aws --version
+                rm -rf "$aws_cli_archive" "$aws_cli_installer"
 
                 id runner >/dev/null 2>&1 || useradd --create-home --shell /bin/bash runner
                 usermod --append --groups docker runner
@@ -227,6 +253,8 @@ Resources:
                 sudo --user runner --set-home ./run.sh
               - RunnerArch: x64
                 RunnerSha256: !Ref RunnerX64Sha256
+                AwsCliArch: x86_64
+                AwsCliSha256: !Ref AwsCliX64Sha256
 
   Arm64LaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
@@ -302,9 +330,23 @@ Resources:
                 export DEBIAN_FRONTEND=noninteractive
                 apt-get update
                 apt-get install --yes --no-install-recommends \
-                  awscli build-essential ca-certificates curl docker-buildx docker.io \
+                  build-essential ca-certificates curl docker-buildx docker.io \
                   git jq npm python3 python3-pip python3-venv sudo tar unzip
                 systemctl enable --now docker
+
+                aws_cli_archive=/tmp/awscliv2.zip
+                aws_cli_installer=/tmp/aws-cli-installer
+                curl --fail --location --retry 5 --retry-all-errors \
+                  --output "$aws_cli_archive" \
+                  "https://awscli.amazonaws.com/awscli-exe-linux-${AwsCliArch}-${AwsCliVersion}.zip"
+                printf '%s  %s\n' '${AwsCliSha256}' "$aws_cli_archive" \
+                  | sha256sum --check --strict
+                install --directory "$aws_cli_installer"
+                unzip -q "$aws_cli_archive" -d "$aws_cli_installer"
+                "$aws_cli_installer/aws/install" \
+                  --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli
+                aws --version
+                rm -rf "$aws_cli_archive" "$aws_cli_installer"
 
                 id runner >/dev/null 2>&1 || useradd --create-home --shell /bin/bash runner
                 usermod --append --groups docker runner
@@ -351,6 +393,8 @@ Resources:
                 sudo --user runner --set-home ./run.sh
               - RunnerArch: arm64
                 RunnerSha256: !Ref RunnerArm64Sha256
+                AwsCliArch: aarch64
+                AwsCliSha256: !Ref AwsCliArm64Sha256
 
   GitHubProvisionRole:
     Type: AWS::IAM::Role

--- a/mcps/cyberful-os/Dockerfile
+++ b/mcps/cyberful-os/Dockerfile
@@ -59,7 +59,15 @@ ADD --checksum=sha256:2e8d42a48e23aefa8a6174b52aa0a8a6b90aca2da0a8bf94ac61f4aaa0
 ADD --checksum=sha256:f2c3035976531130494b5b9dfc02ca0ebd7e0388f740f68b6d4e775098be9fc6 \
   https://github.com/zaproxy/zap-extensions/releases/download/websocket-v37/websocket-release-37.zap \
   /zap/plugin/websocket-release-37.zap
+# ── Pinned Add-ons Must Survive The Runtime UID Boundary ────────────────
+# Docker ADD creates the downloaded archives with mode 0600, owned by the
+# upstream zap user. The unified supervisor deliberately runs ZAP as the host
+# engagement UID instead, so owner-only archives silently disappear from ZAP's
+# add-on catalog. Read-only public archives preserve image immutability while
+# allowing every validated runtime identity to load the exact pinned catalog.
+# ───────────────────────────────────────────────────────────────────────────
 RUN test -s "/zap/zap-${ZAP_VERSION}.jar" \
+  && chmod 0444 /zap/plugin/*.zap \
   && chown -R zap:zap /zap/plugin
 
 FROM --platform=$BUILDPLATFORM ${BUN_BASE_IMAGE} AS zap-bridge-build
@@ -668,7 +676,7 @@ RUN "${CYBERFUL_OS_PYTHON_VENV}/bin/pip" install \
       | grep -q "$(if [[ "${TARGETARCH}" == "amd64" ]]; then echo 'x86-64'; else echo 'ARM aarch64'; fi)" \
   && test -s /zap/zap-x.sh \
   && for addon in ascanrules spiderAjax authhelper graphql mcp oast openapi pscanrules reports websocket; do \
-      test -n "$(find /zap/plugin -name "${addon}-*.zap" -print -quit)"; \
+      test -n "$(find /zap/plugin -name "${addon}-*.zap" -perm -004 -print -quit)"; \
     done \
   && "${CYBERFUL_OS_PYTHON_VENV}/bin/python" /opt/cyberful/runtime-attestation
 

--- a/mcps/cyberful-os/Dockerfile
+++ b/mcps/cyberful-os/Dockerfile
@@ -84,22 +84,6 @@ ENV PATH="${CYBERFUL_OS_PYTHON_VENV}/bin:${PATH}"
 ARG JEB_INSTALLER_URL=""
 ARG JEB_SHA256=""
 ARG GHIDRA_VERSION=12.1.2+ds-0kali1
-ARG ZAP_VERSION
-ARG BUN_VERSION
-ARG BUILD_VERSION=dev
-ARG BUILD_REVISION=unknown
-ENV CYBERFUL_ZAP_VERSION=${ZAP_VERSION}
-
-LABEL org.opencontainers.image.title="cyberful-os" \
-      org.opencontainers.image.description="Unified Cyberful engagement runtime with cyberful-os, OWASP ZAP, and Ghidra" \
-      org.opencontainers.image.source="https://github.com/cyberful/cyberful" \
-      org.opencontainers.image.version="${BUILD_VERSION}" \
-      org.opencontainers.image.revision="${BUILD_REVISION}" \
-      org.opencontainers.image.licenses="AGPL-3.0-only" \
-      org.cyberful.ghidra.version="${GHIDRA_VERSION}" \
-      org.cyberful.zap.version="${ZAP_VERSION}" \
-      org.cyberful.bun.version="${BUN_VERSION}" \
-      org.cyberful.zap.addons="ascanrules=83,spiderAjax=23.32.0,authhelper=0.40.0,graphql=0.33.0,mcp=0.2.0,oast=0.24.0,openapi=57,pscanrules=75,reports=0.46.0,websocket=37"
 
 # ───────────────────────────────────────────────────────────────────────────
 # 1. APT defaults
@@ -660,7 +644,9 @@ COPY cyberful-os/runtime_attestation.py /opt/cyberful/runtime-attestation
 # proves the image selected the decompiler matching TARGETARCH rather than an
 # emulated foreign binary. ZAP remains optional at runtime but complete at build.
 # ───────────────────────────────────────────────────────────────────────────
-ENV GHIDRA_INSTALL_DIR=/usr/share/ghidra \
+ARG ZAP_VERSION
+ENV CYBERFUL_ZAP_VERSION=${ZAP_VERSION} \
+    GHIDRA_INSTALL_DIR=/usr/share/ghidra \
     CYBER_GHIDRA_HOST=127.0.0.1 \
     CYBER_GHIDRA_PORT=47100 \
     CYBER_GHIDRA_STORE=/ghidra/store \
@@ -685,6 +671,28 @@ RUN "${CYBERFUL_OS_PYTHON_VENV}/bin/pip" install \
       test -n "$(find /zap/plugin -name "${addon}-*.zap" -print -quit)"; \
     done \
   && "${CYBERFUL_OS_PYTHON_VENV}/bin/python" /opt/cyberful/runtime-attestation
+
+# ── Volatile Release Metadata Follows Runtime Filesystem Layers ─────────────
+# BUILD_VERSION and BUILD_REVISION change for every published commit, while
+# ZAP and Bun version bumps do not alter the expensive Kali toolchain layers.
+# Consuming those arguments only after installation and attestation lets
+# BuildKit reuse the complete runtime filesystem and regenerate only image
+# metadata when the release identity changes. The final labels remain identical
+# to the public OCI contract consumed by the runtime and release workflows.
+# ───────────────────────────────────────────────────────────────────────────
+ARG BUN_VERSION
+ARG BUILD_VERSION=dev
+ARG BUILD_REVISION=unknown
+LABEL org.opencontainers.image.title="cyberful-os" \
+      org.opencontainers.image.description="Unified Cyberful engagement runtime with cyberful-os, OWASP ZAP, and Ghidra" \
+      org.opencontainers.image.source="https://github.com/cyberful/cyberful" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.revision="${BUILD_REVISION}" \
+      org.opencontainers.image.licenses="AGPL-3.0-only" \
+      org.cyberful.ghidra.version="${GHIDRA_VERSION}" \
+      org.cyberful.zap.version="${ZAP_VERSION}" \
+      org.cyberful.bun.version="${BUN_VERSION}" \
+      org.cyberful.zap.addons="ascanrules=83,spiderAjax=23.32.0,authhelper=0.40.0,graphql=0.33.0,mcp=0.2.0,oast=0.24.0,openapi=57,pscanrules=75,reports=0.46.0,websocket=37"
 
 WORKDIR /workspace
 EXPOSE 8080

--- a/mcps/cyberful-os/tests/test_capability_attestation.py
+++ b/mcps/cyberful-os/tests/test_capability_attestation.py
@@ -195,6 +195,19 @@ class CapabilityReportTest(unittest.TestCase):
         ):
             self.assertIn(smoke, dockerfile[verify_at:workdir_at])
 
+    def test_per_build_metadata_cannot_invalidate_runtime_installation_layers(self):
+        dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+        attestation_at = dockerfile.rindex(
+            '&& "${CYBERFUL_OS_PYTHON_VENV}/bin/python" /opt/cyberful/runtime-attestation'
+        )
+        release_arguments_at = dockerfile.index("ARG BUILD_VERSION=dev")
+        labels_at = dockerfile.index('LABEL org.opencontainers.image.title="cyberful-os"')
+        workdir_at = dockerfile.index("WORKDIR /workspace")
+
+        self.assertLess(attestation_at, release_arguments_at)
+        self.assertLess(release_arguments_at, labels_at)
+        self.assertLess(labels_at, workdir_at)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/mcps/cyberful-os/tests/test_capability_attestation.py
+++ b/mcps/cyberful-os/tests/test_capability_attestation.py
@@ -208,6 +208,19 @@ class CapabilityReportTest(unittest.TestCase):
         self.assertLess(release_arguments_at, labels_at)
         self.assertLess(labels_at, workdir_at)
 
+    def test_pinned_zap_addons_are_readable_by_the_runtime_identity(self):
+        dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+        addon_permissions_at = dockerfile.index("chmod 0444 /zap/plugin/*.zap")
+        runtime_copy_at = dockerfile.index("COPY --from=zap-runtime /zap /zap")
+        runtime_contract_at = dockerfile.index("# 14. Unified runtime contract")
+
+        self.assertLess(addon_permissions_at, runtime_copy_at)
+        self.assertLess(runtime_copy_at, runtime_contract_at)
+        self.assertIn(
+            'find /zap/plugin -name "${addon}-*.zap" -perm -004 -print -quit',
+            dockerfile[runtime_contract_at:],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- defer per-build OCI version and revision arguments until after the final runtime filesystem layer
- consume ZAP and Bun metadata only where the final runtime contract needs it
- add a regression test that prevents volatile release metadata from moving ahead of runtime installation and attestation

## Why

`BUILD_REVISION` changes for every published commit. Consuming it in the early `LABEL` instruction changed the parent cache key for every expensive APT, Python, and security-tool layer that followed. Keeping release identity at the end lets BuildKit reuse the complete runtime filesystem while preserving the same public OCI labels.

## Impact

The runtime contents and labels are unchanged. Pull requests still build and test native amd64 and arm64 images without publishing; after merge, the main workflow will rebuild, publish, assemble, attest, and sign the unified OCI index.

## Validation

- `make typecheck`
- `make test-python` (79 tests)
- `docker buildx build --check --platform linux/amd64 --file mcps/cyberful-os/Dockerfile mcps`
- `git diff --check`
