### PR TITLE
docs: improve developer journey

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,14 @@ cyberful
 ```
 
 The first run pulls one native `amd64` or `arm64` tooling image. The download
-can exceed 6 GB; keep at least 40 GB of disk space free. Packaged releases need
-Docker as their only tooling prerequisite—ZAP, Ghidra, Python, Node, Firefox,
-and Kali tools are inside the image.
+can exceed 6 GB; keep at least 40 GB of disk space free. A standalone binary
+needs Docker as its only host tooling prerequisite; the npm channel also needs
+Node.js and npm for its platform selector. ZAP, Ghidra, Python, Firefox, and
+Kali tools are inside the image.
+
+For a new macOS, Linux, or Windows host, follow [Your first penetration
+test](docs/getting-started/README.md) to install every prerequisite,
+authenticate the provider, verify the environment, and run the workflow.
 
 For a source checkout:
 
@@ -337,8 +342,9 @@ Packaged releases require Docker and one provider configured in
 24 with npm, and Python 3.10+. Keep 40 GB free to run the downloaded image and
 100 GB free when building it locally. Docker Compose is not required.
 
-See the [requirements guide](docs/getting-started/requirements.md) for macOS,
-Linux, and Windows setup.
+See the [requirements guide](docs/getting-started/requirements.md) for the host
+contract and the [fresh-host walkthrough](docs/getting-started/README.md) for
+complete macOS, Linux, and Windows setup.
 
 ## Build and test
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,12 +29,6 @@ hide:
   </figure>
 </section>
 
-<div class="cyberful-proof">
-  <div class="cyberful-proof__item"><strong>3 workflows</strong><span>Pentest, bug bounty, and code audit</span></div>
-  <div class="cyberful-proof__item"><strong>Independent verification</strong><span>Evidence before conclusions</span></div>
-  <div class="cyberful-proof__item"><strong>Scoped by design</strong><span>Authorization is a system boundary</span></div>
-</div>
-
 <section class="cyberful-home-section">
   <div class="cyberful-section-heading cyberful-section-heading--editorial">
     <div>

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,11 +2,11 @@
 
 - [Home](README.md)
 
-## Start
+## Getting Start
 
+- [Your first penetration test](getting-started/README.md)
 - [What you need](getting-started/requirements.md)
 - [Install Cyberful](getting-started/install.md)
-- [Your first penetration test](getting-started/README.md)
 
 ## Use Cyberful
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,65 +1,492 @@
 # Your first penetration test
 
-This walkthrough takes you from a working Cyberful installation to completing
-a first penetration test in the terminal interface.
+This walkthrough starts with a fresh supported computer and ends with an
+authenticated Cyberful installation that can run a first penetration test and
+produce its report. Follow **one** operating-system path from beginning to end,
+then continue with [Run the first test](#run-the-first-test).
 
 > Use Cyberful only against systems you are authorized to test. Before you
-> begin, know the exact targets, exclusions, test window, and traffic limits for
-> the engagement.
+> begin, know the exact targets, exclusions, test window, account permissions,
+> and traffic limits for the engagement.
 
-Install the Cyberful CLI globally if it is not already available:
+## What this walkthrough installs
+
+Cyberful needs four things on the host:
+
+| Component | Why it is needed |
+| --- | --- |
+| **Docker** | Runs the isolated Cyberful security environment |
+| **Node.js and npm** | Installs the small npm package that selects the native Cyberful executable |
+| **Cyberful CLI** | Starts the TUI, owns sessions, and writes evidence and reports |
+| **A model-provider login** | Authenticates the default `openai-codex` provider through its browser or device-code flow |
+
+Do **not** install ZAP, Ghidra, Firefox, Python, Bun, a JDK, or offensive tools
+on the host. They are already inside the Cyberful runtime image. Docker Compose
+is not required.
+
+Cyberful also does **not** require Chrome, Safari, Edge, or another personal
+browser for security testing. The release contains its browser driver and
+automatically downloads a pinned, open-source Chromium build on first launch
+(about 150 MB). Chromium is stored in Cyberful's cache and uses dedicated
+profiles, so Cyberful never drives or locks your everyday browser profile. A
+system browser is useful only to complete the model provider's OAuth or
+device-code login; if Cyberful cannot open it automatically, it prints the URL
+and code so you can open them in any browser.
+
+Have these ready before starting:
+
+- an administrator account on the computer;
+- a browser and an account with access to the default OpenAI Codex provider;
+- an unrestricted internet connection for the Docker, npm, runtime-image, and
+  provider-authentication downloads;
+- at least **40 GB of free disk space**. The first compressed runtime download
+  can exceed 6 GB and needs substantially more space after extraction;
+- the written authorization and scope for the penetration test.
+
+The npm release supports these host platforms:
+
+| Host | Supported architecture |
+| --- | --- |
+| macOS | Apple silicon (`arm64`) and Intel (`x86_64`) |
+| Linux | `x86_64` with glibc |
+| Windows | 64-bit x86 (`AMD64`) |
+
+The runtime image also has an ARM64 Linux variant, but the npm release does not
+currently publish a Linux ARM64 CLI package. Linux ARM64 and musl-based systems
+such as Alpine therefore need a source build and are outside this fresh-host
+walkthrough.
+
+## macOS: install everything
+
+These steps work on a supported Apple silicon or Intel Mac.
+
+### 1. Check the Mac
+
+Open **Terminal** and run:
 
 ```sh
-npm i -g cyberful
+uname -m
+df -h "$HOME"
 ```
 
-See [Install Cyberful](install.md) for source builds and other installation
-details.
+`uname -m` must print `arm64` or `x86_64`. Confirm that the disk containing your
+home directory has at least 40 GB available.
 
-## 1. Confirm the installation
+### 2. Install and start Docker Desktop
 
-Confirm that Cyberful, its main provider, and Docker are ready:
+1. Open the official [Docker Desktop for Mac installation
+   page](https://docs.docker.com/desktop/setup/install/mac-install/).
+2. Download the installer for **Apple silicon** when `uname -m` printed
+   `arm64`, or **Intel** when it printed `x86_64`.
+3. Open `Docker.dmg`, drag Docker to **Applications**, then start Docker.
+4. Accept the terms and keep the recommended settings when Docker asks for its
+   initial configuration.
+5. Wait until Docker Desktop reports that the engine is running.
+
+Verify both the Docker client and server:
+
+```sh
+docker version
+docker info --format '{{.OSType}}'
+docker run --rm hello-world
+```
+
+The second command must print `linux`, and the last command must finish with
+Docker's success message. Do not continue while `docker version` reports only a
+client or cannot contact the server.
+
+### 3. Install Node.js and npm
+
+Install the current Node.js LTS line with `nvm`. This also installs npm without
+requiring `sudo` for global npm packages:
+
+```sh
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.5/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+nvm install 24
+nvm alias default 24
+node --version
+npm --version
+```
+
+Both version commands must print a version. Cyberful requires Node.js 18 or
+newer; Node.js 24 is the current LTS line used by this walkthrough. See the
+official [Node.js download page](https://nodejs.org/en/download) if the `nvm`
+installer has been superseded.
+
+### 4. Install Cyberful
+
+```sh
+npm install --global cyberful
+cyberful --version
+```
+
+If the shell cannot find `cyberful`, close Terminal, open it again, and rerun
+`cyberful --version`.
+
+### 5. Create the engagement and authenticate
+
+Create a dedicated directory. Run the authentication commands **from this
+directory**, because Cyberful creates and loads its local `settings.yaml` here:
+
+```sh
+mkdir -p "$HOME/cyberful-engagements/acme-web"
+cd "$HOME/cyberful-engagements/acme-web"
+cyberful auth login
+cyberful auth status
+```
+
+Cyberful opens the default provider's browser or device-code login. Complete
+the sign-in and return to Terminal. The final command must include:
+
+```text
+Provider: openai-codex
+Status: available
+```
+
+The subscription credential is kept in Cyberful's owner-only credential store;
+it is not written to `settings.yaml`, prompts, transcripts, or reports.
+
+Your Mac is ready. Keep this Terminal open and continue with
+[Run the first test](#run-the-first-test).
+
+## Linux: install everything
+
+The published npm package requires a 64-bit x86 Linux distribution with glibc.
+The Docker steps below cover current Ubuntu, Debian, and Fedora releases.
+
+### 1. Check the Linux host
+
+Open a terminal and run:
+
+```sh
+uname -m
+ldd --version | head -n 1
+df -h "$HOME"
+```
+
+`uname -m` must print `x86_64`, `ldd` must identify glibc or GNU libc, and the
+disk containing your home directory must have at least 40 GB available.
+
+### 2. Install Docker Engine
+
+Use the block for your distribution. These commands add Docker's official
+package repository and install Docker Engine, its CLI, containerd, Buildx, and
+the Compose plugin. Cyberful itself does not require Compose.
+
+#### Ubuntu
+
+Follow this path on a currently supported Ubuntu release:
+
+```sh
+sudo apt update
+sudo apt install -y ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+sudo tee /etc/apt/sources.list.d/docker.sources >/dev/null <<EOF
+Types: deb
+URIs: https://download.docker.com/linux/ubuntu
+Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+Components: stable
+Architectures: $(dpkg --print-architecture)
+Signed-By: /etc/apt/keyrings/docker.asc
+EOF
+sudo apt update
+sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo systemctl enable --now docker
+```
+
+The commands follow Docker's official [Ubuntu installation
+procedure](https://docs.docker.com/engine/install/ubuntu/).
+
+#### Debian
+
+Follow this path on a currently supported Debian release:
+
+```sh
+sudo apt update
+sudo apt install -y ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+sudo tee /etc/apt/sources.list.d/docker.sources >/dev/null <<EOF
+Types: deb
+URIs: https://download.docker.com/linux/debian
+Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")
+Components: stable
+Architectures: $(dpkg --print-architecture)
+Signed-By: /etc/apt/keyrings/docker.asc
+EOF
+sudo apt update
+sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo systemctl enable --now docker
+```
+
+The commands follow Docker's official [Debian installation
+procedure](https://docs.docker.com/engine/install/debian/). On a Debian-derived
+distribution, use the corresponding Debian codename as Docker documents; do
+not assume that an unsupported derivative is equivalent to Debian.
+
+#### Fedora
+
+Follow this path on a currently supported Fedora release:
+
+```sh
+sudo dnf install -y curl
+sudo dnf config-manager addrepo --from-repofile https://download.docker.com/linux/fedora/docker-ce.repo
+sudo dnf install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo systemctl enable --now docker
+```
+
+When prompted to accept Docker's GPG key, compare the fingerprint with the one
+published in Docker's official [Fedora installation
+procedure](https://docs.docker.com/engine/install/fedora/) before accepting it.
+
+#### Allow your user to run Docker
+
+Cyberful must be able to reach Docker without `sudo`. Add the current user to
+Docker's group:
+
+```sh
+sudo usermod -aG docker "$USER"
+```
+
+Sign out and back in, or activate the new membership immediately by running:
+
+```sh
+newgrp docker
+```
+
+The command opens a refreshed shell. Test the engine from that shell:
+
+```sh
+docker version
+docker info --format '{{.OSType}}'
+docker run --rm hello-world
+```
+
+The second Docker command must print `linux`, and `hello-world` must finish
+successfully. The `docker` group grants root-level privileges; read Docker's
+[Linux post-installation warning](https://docs.docker.com/engine/install/linux-postinstall/)
+before adding users on a shared host. The group membership is persistent, but
+you may need to sign out and back in for new terminals to see it.
+
+### 3. Install Node.js and npm
+
+Install the current Node.js LTS line with `nvm`:
+
+```sh
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.5/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+nvm install 24
+nvm alias default 24
+node --version
+npm --version
+```
+
+Both version commands must print a version. Cyberful requires Node.js 18 or
+newer; Node.js 24 is the current LTS line used by this walkthrough. See the
+official [Node.js download page](https://nodejs.org/en/download) if the `nvm`
+installer has been superseded.
+
+### 4. Install Cyberful
+
+```sh
+npm install --global cyberful
+cyberful --version
+```
+
+If a new terminal cannot find Node.js or Cyberful, sign out and back in, then
+rerun the two version checks. Do not reinstall the npm package with `sudo`.
+
+### 5. Create the engagement and authenticate
+
+Create a dedicated directory and authenticate from inside it:
+
+```sh
+mkdir -p "$HOME/cyberful-engagements/acme-web"
+cd "$HOME/cyberful-engagements/acme-web"
+cyberful auth login
+cyberful auth status
+```
+
+Complete the browser or device-code login. The status output must include:
+
+```text
+Provider: openai-codex
+Status: available
+```
+
+Cyberful stores the subscription credential in its owner-only credential store,
+not in the local `settings.yaml` it creates for the engagement.
+
+Your Linux host is ready. Keep this terminal open and continue with
+[Run the first test](#run-the-first-test).
+
+## Windows: install everything
+
+This path installs and runs Cyberful natively in 64-bit Windows PowerShell.
+WSL 2 provides Docker Desktop's backend; a Linux distribution is not required
+for this walkthrough.
+
+### 1. Check Windows and enable WSL 2
+
+Confirm that virtualization is enabled in the computer's firmware and that the
+machine satisfies Docker Desktop's current [Windows system
+requirements](https://docs.docker.com/desktop/setup/install/windows-install/).
+Then open **PowerShell as Administrator** and run:
+
+```powershell
+$env:PROCESSOR_ARCHITECTURE
+Get-PSDrive -Name C
+wsl --install --no-distribution
+```
+
+The architecture must be `AMD64`, and the drive that will hold Docker data and
+your workarea needs at least 40 GB free. Restart Windows if `wsl --install`
+requests it. After the restart, reopen PowerShell as Administrator and run:
+
+```powershell
+wsl --update
+wsl --version
+```
+
+If `wsl --install` is unavailable or fails, follow Microsoft's official [WSL
+installation instructions](https://learn.microsoft.com/windows/wsl/install)
+before continuing.
+
+### 2. Install Node.js, npm, and Docker Desktop
+
+In the administrator PowerShell window, install the current Node.js LTS release
+and Docker Desktop from WinGet:
+
+```powershell
+winget install --exact --id OpenJS.NodeJS.LTS --source winget --accept-source-agreements --accept-package-agreements
+winget install --exact --id Docker.DockerDesktop --source winget --accept-source-agreements --accept-package-agreements
+```
+
+If `winget` is missing, install or update **App Installer** as described in
+Microsoft's [WinGet documentation](https://learn.microsoft.com/windows/package-manager/winget/),
+then rerun the commands.
+
+Close PowerShell, open a new ordinary PowerShell window, and verify Node.js and
+npm:
+
+```powershell
+node --version
+npm --version
+```
+
+Both commands must print a version. Cyberful requires Node.js 18 or newer; the
+WinGet LTS package installs a supported release.
+
+### 3. Start and verify Docker Desktop
+
+1. Start **Docker Desktop** from the Windows Start menu.
+2. Accept the terms and finish the initial setup.
+3. In **Settings > General**, keep **Use the WSL 2 based engine** enabled.
+4. If the Docker Desktop menu offers **Switch to Linux containers**, select it.
+   If it offers **Switch to Windows containers**, Linux containers are already
+   active.
+5. Wait until Docker Desktop reports that the engine is running.
+
+Return to PowerShell and run:
+
+```powershell
+docker version
+docker info --format '{{.OSType}}'
+docker run --rm hello-world
+```
+
+The second command must print `linux`, and the last command must finish with
+Docker's success message. Cyberful cannot use the Windows-container engine.
+
+### 4. Install Cyberful
+
+```powershell
+npm install --global cyberful
+cyberful --version
+```
+
+If PowerShell cannot find `cyberful`, close it, open a new PowerShell window,
+and rerun `cyberful --version`.
+
+### 5. Create the engagement and authenticate
+
+Create a dedicated directory and authenticate from inside it:
+
+```powershell
+New-Item -ItemType Directory -Force "$HOME\cyberful-engagements\acme-web" | Out-Null
+Set-Location "$HOME\cyberful-engagements\acme-web"
+cyberful auth login
+cyberful auth status
+```
+
+Complete the browser or device-code login. The status output must include:
+
+```text
+Provider: openai-codex
+Status: available
+```
+
+Cyberful stores the subscription credential in its owner-only credential store,
+not in the local `settings.yaml` it creates for the engagement.
+
+Your Windows host is ready. Keep this PowerShell window open and continue with
+the next section.
+
+## Run the first test
+
+All three installation paths leave the terminal in the engagement directory.
+Keep using that same directory for the remaining steps.
+
+### 1. Run the final readiness check
+
+On macOS or Linux:
 
 ```sh
 cyberful --version
 cyberful auth status
 docker version
+docker info --format '{{.OSType}}'
 ```
 
-If a check fails, return to [What you need](requirements.md) before creating the
-engagement directory.
+On Windows PowerShell:
 
-## 2. Create an engagement directory
-
-Use a dedicated directory for the engagement. Cyberful will keep its workarea,
-evidence, logs, and reports below this directory.
-
-```sh
-mkdir -p ~/cyberful-engagements/acme-web
-cd ~/cyberful-engagements/acme-web
+```powershell
+cyberful --version
+cyberful auth status
+docker version
+docker info --format '{{.OSType}}'
 ```
 
-You can place non-secret scope notes, API descriptions, sample requests, or
-architecture diagrams here and attach them from the TUI when writing the
-mission.
+Authentication must be `available`, Docker must report both a client and a
+server, and the Docker OS type must be `linux`.
 
-## 3. Launch the TUI
-
-Start Cyberful from the engagement directory:
+### 2. Launch the TUI
 
 ```sh
 cyberful
 ```
 
-Before opening the TUI, Cyberful validates `settings.yaml`, checks the selected
-Pi provider and credentials, verifies Docker, and prepares its container
-images. On the first launch it may also download the isolated Chromium browser.
-The first startup can therefore take longer than later ones.
+Before opening the TUI, Cyberful validates `settings.yaml`, resolves the main
+provider credential, verifies Docker, and prepares the immutable runtime image.
+The first compressed image download can exceed 6 GB, so the first start can
+take much longer than later ones. Leave Docker and the terminal running while
+the pull and image attestation complete. On first use, Cyberful also downloads
+about 150 MB for its isolated Chromium browser and stores it in its persistent
+cache; no browser installation step is required.
 
-If the provider is not authenticated or Docker is not running, Cyberful stops
-with an actionable message. Fix the reported dependency and launch it again.
+If the preflight stops, fix the specific failed check and run `cyberful` again.
+Cyberful does not begin a security workflow with a missing provider credential
+or an unavailable Docker server. A failed Chromium download is reported as a
+degraded browser capability: relaunch Cyberful to retry before starting a test
+that needs browser automation.
 
-## 4. Name the workarea
+### 3. Name the workarea
 
 The home screen asks for a **Workarea**. Use a short, engagement-specific name:
 
@@ -78,7 +505,7 @@ It will contain the mission, phase artifacts, evidence, proof-of-concept
 material, and final report. A workarea is a name, not a path, so do not use `/`,
 `\`, or `..`.
 
-## 5. Select Pentest
+### 4. Select Pentest
 
 Pentest is selected by default in a standard installation. Check the workflow
 shown in the composer before starting.
@@ -93,7 +520,7 @@ Brief and advances through this chain:
 brief → recon → exploit → hacker → verify → report
 ```
 
-## 6. Describe the engagement
+### 5. Describe the engagement
 
 The first message becomes the input for Brief. State the authorization and
 scope precisely. For example:
@@ -149,19 +576,19 @@ testing targets unless the supplied authorization independently covers them.
 
 When the mission is clear, submit the message with `Enter`.
 
-## 7. Follow the phases
+### 6. Follow the phases
 
 Cyberful advances automatically after each phase writes its required artifact
 and completes a valid handoff:
 
-| Phase       | What it does                                                  |
-| ----------- | ------------------------------------------------------------- |
-| **Brief**   | Records scope, authorization, access, and rules of engagement |
-| **Recon**   | Maps the surface and calibrates evidence-backed candidates    |
-| **Exploit** | Confirms candidates with controlled, reproducible evidence    |
-| **Hacker**  | Investigates attack chains and higher-order hypotheses        |
-| **Verify**  | Independently retests every confirmed claim                   |
-| **Report**  | Produces the final client-facing report                       |
+| Phase | What it does |
+| --- | --- |
+| **Brief** | Records scope, authorization, access, and rules of engagement |
+| **Recon** | Maps the surface and calibrates evidence-backed candidates |
+| **Exploit** | Confirms candidates with controlled, reproducible evidence |
+| **Hacker** | Investigates attack chains and higher-order hypotheses |
+| **Verify** | Independently retests every confirmed claim |
+| **Report** | Produces the final client-facing report |
 
 The activity feed shows the current phase, public reasoning updates, tool use,
 warnings, and saved evidence. If Cyberful needs a blocking decision, it opens a
@@ -179,7 +606,7 @@ active phase; it does not silently expand the authorized scope.
 Press `Ctrl+P` whenever you need the context-aware list of actions available on
 the current screen.
 
-## 8. Open the report
+### 7. Open the report
 
 When Report finishes, Cyberful displays a completion card with the validated
 result. The primary Pentest deliverable is:
@@ -206,5 +633,20 @@ After completion, the session switches to **Ask**. You can use it to explore a
 finding, locate evidence, discuss remediation, or plan a follow-up test without
 losing the completed workarea.
 
-For the responsibilities and boundaries of all three security workflows, continue with
+## If a readiness check fails
+
+| Symptom | What to do |
+| --- | --- |
+| `cyberful: command not found` or “not recognized” | Open a new terminal. Confirm `node --version` and `npm --version`, then rerun `npm install --global cyberful`. |
+| Docker shows a client but no server | Start Docker Desktop on macOS or Windows; on Linux run `sudo systemctl start docker`. |
+| Docker reports `permission denied` on Linux | Run `newgrp docker`, or sign out and back in after adding the user to the `docker` group. |
+| Docker OS type is `windows` | Switch Docker Desktop to Linux containers and wait for the engine to restart. |
+| Authentication status is `missing` | From the engagement directory, rerun `cyberful auth login`, finish the browser/device flow, then run `cyberful auth status`. |
+| The Chromium download fails | Confirm that the host can reach the download service, then relaunch Cyberful. The preflight retries until the isolated browser is available. |
+| npm reports an unsupported platform | Confirm the host matches the release matrix near the top of this page. Source builds are documented in [Install Cyberful](install.md). |
+| The first launch runs out of space | Free enough space to leave at least 40 GB available, start Docker again, then rerun `cyberful`. |
+
+For alternative model providers, credential sources, and fallback routes, see
+[Agent providers and fallback](../user-guide/settings.md). For the
+responsibilities and boundaries of all three security workflows, continue with
 [Application security workflows](../user-guide/workflows.md).

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -1,7 +1,9 @@
 # Install Cyberful
 
 Choose the standard npm installation unless you are developing Cyberful or need
-to build its binaries yourself.
+to build its binaries yourself. If the computer does not yet have Docker,
+Node.js, npm, or a configured provider, use the complete OS-specific
+[fresh-host walkthrough](README.md) instead of starting on this page.
 
 ## Install the release
 
@@ -14,10 +16,12 @@ cyberful --version
 
 The unscoped `cyberful` package installs the command and selects the matching
 native package from the `@cyberful-org` npm organization. This path does not
-require Bun.
+require Bun. Published packages cover macOS on Apple silicon and Intel, Linux
+on `x86_64` with glibc, and 64-bit x86 Windows.
 
 Cyberful creates a secret-free `settings.yaml` with OpenAI Codex as the default
-Pi provider. Authenticate that route through Cyberful:
+Pi provider. From the directory that will contain the engagement, authenticate
+that route through Cyberful:
 
 ```sh
 cyberful auth login

--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -12,6 +12,11 @@ runtime prerequisites.
 | Develop from this repository | Docker, Bun 1.3.14, Node.js 24 with npm, and Python 3.10+ |
 | Build the runtime image | The development tools above and at least 100 GB free |
 
+The published npm release supports macOS on Apple silicon and Intel, Linux on
+`x86_64` with glibc, and 64-bit x86 Windows. For a complete fresh-host setup,
+including Docker, Node.js, npm, Cyberful, provider authentication, and the first
+workflow, follow [Your first penetration test](README.md) from the beginning.
+
 Check the runtime prerequisite before installing:
 
 ```sh
@@ -23,6 +28,12 @@ or Node installation is not required by a standalone release binary. The npm
 distribution channel still uses Node for its portable platform selector; the
 selected Cyberful executable and its embedded browser driver do not.
 
+A personal Chrome, Safari, Edge, or Firefox installation is not a runtime
+requirement. On first launch, the installed release automatically downloads its
+pinned Chromium build (about 150 MB) into Cyberful's persistent cache and uses
+dedicated profiles. The system browser is used only for provider login when it
+is available; the CLI also prints the OAuth or device-code URL for manual use.
+
 ## First launch and disk capacity
 
 The release CLI pulls one immutable multi-architecture image from
@@ -32,10 +43,11 @@ layer, browser, persistent Ghidra projects, workarea evidence, and reports.
 Building the image from source requires at least **100 GB free**.
 
 The image index contains native `linux/amd64` and `linux/arm64` manifests.
-Docker selects the matching manifest automatically. Cyberful prints the full
-image reference, selected architecture, and digest while pulling or attesting
-the runtime. A local source checkout instead defaults to `cyberful-os:latest`;
-build it with:
+Docker selects the matching manifest automatically. This does not add a Linux
+ARM64 package to the npm release: Linux ARM64 currently requires a source
+build. Cyberful prints the full image reference, selected architecture, and
+digest while pulling or attesting the runtime. A local source checkout instead
+defaults to `cyberful-os:latest`; build it with:
 
 ```sh
 make runtime-build
@@ -51,8 +63,9 @@ docker image prune
 
 ## Provider setup
 
-The first launch creates `settings.yaml` with `openai-codex` as the main
-subscription provider. Authenticate and inspect that route through Cyberful:
+The first command run in a new engagement directory creates `settings.yaml`
+with `openai-codex` as the main subscription provider. Authenticate and inspect
+that route from the same directory:
 
 ```sh
 cyberful auth login

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -239,9 +239,9 @@ body {
 
 .md-nav__title,
 .md-nav__item--section > .md-nav__link {
-  font-family: var(--cyberful-serif);
-  font-optical-sizing: auto;
+  font-family: var(--cyberful-ui);
   font-weight: 700;
+  letter-spacing: -0.02em;
 }
 
 .md-nav--secondary .md-nav__title {
@@ -311,6 +311,19 @@ body {
 
 .md-typeset p {
   margin: 1em 0;
+}
+
+.md-content__inner:not(:has(> .cyberful-home)) a:not(.headerlink, .md-button) {
+  color: var(--cyberful-blue);
+  text-decoration: underline;
+  text-decoration-color: currentColor;
+  text-decoration-thickness: 0.06em;
+  text-underline-offset: 0.16em;
+}
+
+.md-content__inner:not(:has(> .cyberful-home)) a:not(.headerlink, .md-button):is(:hover, :focus-visible) {
+  color: var(--md-typeset-a-color);
+  text-decoration-thickness: 0.09em;
 }
 
 .md-typeset blockquote {
@@ -483,6 +496,7 @@ body {
 .md-typeset .md-button {
   border: 1px solid var(--cyberful-line);
   border-radius: 0.58rem;
+  color: var(--md-default-fg-color);
   font-weight: 720;
   padding: 0.62rem 1rem;
   transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
@@ -620,43 +634,6 @@ body {
   position: relative;
   width: 100%;
   z-index: 1;
-}
-
-.cyberful-proof {
-  background: var(--md-default-bg-color);
-  border: 1px solid var(--cyberful-line);
-  border-radius: 0.95rem;
-  box-shadow: 0 0.8rem 2.8rem rgb(4 8 16 / 7%);
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  margin: -1.15rem clamp(1.1rem, 2vw, 2rem) 4.5rem;
-  position: relative;
-  z-index: 2;
-}
-
-.cyberful-proof__item {
-  padding: 1.15rem 1.35rem;
-}
-
-.cyberful-proof__item + .cyberful-proof__item {
-  border-left: 1px solid var(--cyberful-line);
-}
-
-.cyberful-proof strong,
-.cyberful-proof span {
-  display: block;
-}
-
-.cyberful-proof strong {
-  font-family: var(--cyberful-serif);
-  font-size: 0.95rem;
-  font-weight: 640;
-}
-
-.cyberful-proof span {
-  color: var(--cyberful-muted);
-  font-size: 0.6rem;
-  margin-top: 0.18rem;
 }
 
 .cyberful-home-section {
@@ -1025,10 +1002,6 @@ body {
     margin-top: 1rem;
   }
 
-  .cyberful-proof {
-    margin: -0.9rem 0.8rem 3.5rem;
-  }
-
   .cyberful-home-section {
     margin: 3.6rem 0;
     padding: 0 0.8rem;
@@ -1044,18 +1017,12 @@ body {
 
   .cyberful-workflow-grid,
   .cyberful-card-grid,
-  .cyberful-proof,
   .cyberful-deep-grid {
     grid-template-columns: 1fr;
   }
 
   .cyberful-workflow-card {
     min-height: 14rem;
-  }
-
-  .cyberful-proof__item + .cyberful-proof__item {
-    border-left: 0;
-    border-top: 1px solid var(--cyberful-line);
   }
 
   .cyberful-section-heading,

--- a/docs/user-guide/sessions-and-reports.md
+++ b/docs/user-guide/sessions-and-reports.md
@@ -45,6 +45,15 @@ Use `session steer` to add short, routine guidance to an AgentRun that is
 already running. The ordinary TUI uses an internal transport, so expose its
 loopback control plane when starting it.
 
+This control-plane path is also useful when Cyberful runs under the supervision
+of an external coding agent such as Codex, Claude Code, Kimi, or a similar
+orchestrator. The supervising agent can keep the TUI as the operator's view and
+send bounded `session steer` messages from its own process instead of trying to
+drive the terminal UI. This is an out-of-band guidance path, not shared
+ownership of the run: it reaches only the currently busy root AgentRun, never
+starts a turn, and carries no approval, authorization, provider, model, or
+phase authority.
+
 Terminal 1:
 
 ```sh

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,7 +54,6 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.sections
-    - navigation.indexes
     - navigation.top
     - navigation.footer
     - content.action.edit
@@ -66,7 +65,7 @@ theme:
     - search.share
 
 extra_css:
-  - stylesheets/extra.css?v=cyberful-codeblocks-v1
+  - stylesheets/extra.css?v=cyberful-ui-v2
 
 extra:
   generator: false
@@ -110,11 +109,11 @@ validation:
     unrecognized_links: info
 
 nav:
-  - Overview: README.md
-  - Start:
+  - Home: README.md
+  - Getting Start:
+      - Your first penetration test: getting-started/README.md
       - What you need: getting-started/requirements.md
       - Install Cyberful: getting-started/install.md
-      - Your first penetration test: getting-started/README.md
   - Use Cyberful:
       - Choose a workflow: user-guide/workflows.md
       - Terminal interface: user-guide/interface.md


### PR DESCRIPTION
## What changed

- Rebuilt **Your first penetration test** into a self-contained fresh-host walkthrough for macOS, Linux, and Windows.
- Added Docker, Node.js/npm, Cyberful, provider authentication, platform constraints, disk requirements, readiness checks, isolated Chromium provisioning, and troubleshooting.
- Aligned the requirements, installation guide, and root README with the published release targets and real authentication flow.
- Improved the documentation navigation and visual behavior: non-clickable section groups, clearer Home/Getting Start labels, readable inline links, corrected dark-mode secondary actions, and cleaner sidebar typography.
- Removed the homepage proof strip and documented out-of-band steering for external coding-agent supervisors.

## Why

The previous onboarding path assumed a working Cyberful installation and spread required setup across several pages. A developer or operator starting from a clean machine could not reliably reach an authenticated, working first run from one guide. Some documentation theme states also obscured links or actions and made the navigation hierarchy ambiguous.

## Impact

A new user can now follow one OS-specific path from an empty host through dependency installation, authentication, first launch, workflow execution, and report discovery. The changes affect documentation and presentation only; runtime behavior is unchanged.

## Validation

- `make docs-build`
- `git diff --check`
