### PR TITLE
fix(infra): authorize scheduled runner cleanup

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -103,6 +103,8 @@ job, and has a four-hour shutdown deadline. A failed bootstrap remains alive
 only long enough for the provisioning job to copy its serial-console output
 into the private Actions log, then the same failure trap terminates it. The
 trusted cleanup workflow on `main` handles cancellation and an hourly
-stale-capacity sweep. Both the GitHub Actions runner and the official AWS CLI
-v2 installer are version-pinned and checksum-verified independently for amd64
-and arm64 before execution.
+stale-capacity sweep. Its provisioning role can enumerate only the
+`/cyberful/github-runners` parameter hierarchy; creation and deletion remain
+restricted to parameters below that root. Both the GitHub Actions runner and
+the official AWS CLI v2 installer are version-pinned and checksum-verified
+independently for amd64 and arm64 before execution.

--- a/infra/github-runners.yml
+++ b/infra/github-runners.yml
@@ -477,12 +477,17 @@ Resources:
                 Condition:
                   StringEquals:
                     iam:PassedToService: ec2.amazonaws.com
+              - Sid: EnumerateOneTimeRegistrationTokens
+                Effect: Allow
+                Action: ssm:GetParametersByPath
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/cyberful/github-runners
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/cyberful/github-runners/*
               - Sid: ManageOneTimeRegistrationTokens
                 Effect: Allow
                 Action:
                   - ssm:DeleteParameter
                   - ssm:DeleteParameters
-                  - ssm:GetParametersByPath
                   - ssm:PutParameter
                 Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/cyberful/github-runners/*
       Tags:


### PR DESCRIPTION
## Summary

- authorize `ssm:GetParametersByPath` on the exact `/cyberful/github-runners` root used by the hourly sweep
- retain child-only resource access for token creation and deletion
- document the resulting least-privilege boundary

## Cause

The scheduled cleanup queries the hierarchy root, but the IAM policy only matched `parameter/cyberful/github-runners/*`. Systems Manager requires exact path matching, so the root ARN was not authorized even though child paths were.

## Verification

- CloudFormation YAML syntax parse
- policy-shape assertions for root and child ARNs
- `git diff --check`
- `uv run --with-requirements docs-requirements.txt mkdocs build --strict`

## Security and release impact

- [x] The change stays within Cyberful's authorization and no-telemetry boundaries.
- [x] No credentials, engagement data, transcripts, reports, browser profiles, or runtime state are included.
- [x] Tests cover behavior changes and documentation is updated where required.
- [x] New or redistributed dependencies and assets have compatible provenance and notices.