### PR TITLE
feat: expose browser profiles through global CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ cyberful
 the Cyberful security image and installs its isolated Chromium browser. Keep at
 least 40 GB of disk space free.
 
+Open any persistent browser identity before a test with `cyberful browser-1`
+through `cyberful browser-5`. Sign in only to the authorized target account,
+then fully close the browser so Cyberful can reuse that profile during the test.
+
 For complete fresh-machine instructions on macOS, Linux, and Windows, follow
 **[Your first penetration test](https://cyberful.io/getting-started/)**.
 

--- a/cyberful/script/browser-run.ts
+++ b/cyberful/script/browser-run.ts
@@ -1,14 +1,12 @@
 // ── Manual Browser Profile Launcher ─────────────────────────────────
 // Opens one of Cyberful's five persistent browser identities so a human can
 // establish an authorized target session before starting the application.
-// → cyberful/src/dependency/browser-profile.ts — resolves stable profile paths.
-// → mcps/browser/browser_mcp.mjs — owns the headed Chromium process and profile lock.
+// → cyberful/src/dependency/browser-profile-launcher.ts — owns the shared CLI lifecycle.
 // @docs/runtimes/browser.md
 // ─────────────────────────────────────────────────────────────────────
 
-import path from "node:path"
-import { fileURLToPath } from "node:url"
 import { BrowserProfile } from "../src/dependency/browser-profile"
+import { BrowserProfileLauncher } from "../src/dependency/browser-profile-launcher"
 
 const profileArgument = process.argv[2]
 const profile = Number(profileArgument)
@@ -17,30 +15,4 @@ if (!BrowserProfile.isBrowserProfileId(profile)) {
   process.exit(2)
 }
 
-const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..")
-const launcher = path.join(repositoryRoot, "mcps", "browser", "bin", "cyber-browser")
-const profileDirectory = BrowserProfile.browserProfileDir(profile)
-
-process.stderr.write(`Opening Cyberful browser profile ${profile}: ${profileDirectory}\n`)
-process.stderr.write("Sign in to the authorized target, then close the browser before starting Cyberful.\n")
-
-const child = Bun.spawn([launcher], {
-  env: BrowserProfile.manualBrowserProfileEnv(profile),
-  stdin: "inherit",
-  stdout: "inherit",
-  stderr: "inherit",
-})
-
-// ── The Manual Launcher Owns Browser Shutdown ───────────────────────
-// Eager browser mode intentionally waits forever while the Chromium window is
-// open. Terminal interruption must therefore reach the child, which performs
-// bounded context cleanup and releases the persistent profile lock. Closing the
-// browser normally exits the child and requires no second cleanup attempt. The
-// parent waits for that exit so a completed Make target proves the profile is
-// available to the next Cyberful phase gateway.
-// ─────────────────────────────────────────────────────────────────────
-for (const signal of ["SIGINT", "SIGTERM"] as const) {
-  process.once(signal, () => child.kill(signal))
-}
-
-process.exitCode = await child.exited
+process.exitCode = await BrowserProfileLauncher.launchBrowserProfile(profile)

--- a/cyberful/src/cli/cmd/browser.test.ts
+++ b/cyberful/src/cli/cmd/browser.test.ts
@@ -1,0 +1,32 @@
+// ── Browser Profile CLI Command Tests ───────────────────────────────
+// Protects the exact browser-N command surface and its bounded invalid-profile
+// error before any browser process or persistent state can be touched.
+// → cyberful/src/cli/cmd/browser.ts — parses the tested public commands.
+// @docs/user-guide/interface.md
+// ─────────────────────────────────────────────────────────────────────
+
+import { describe, expect, test } from "bun:test"
+import {
+  BROWSER_PROFILE_COMMANDS,
+  browserProfileCommandKind,
+  browserProfileFromCommand,
+  invalidBrowserProfileMessage,
+} from "./browser"
+
+describe("browser profile CLI command", () => {
+  test("accepts every supported browser-N command", () => {
+    expect(BROWSER_PROFILE_COMMANDS.map(browserProfileFromCommand)).toEqual([1, 2, 3, 4, 5])
+  })
+
+  test("rejects unsupported and malformed profile identifiers clearly", () => {
+    expect(browserProfileCommandKind("browser-5")).toBe("supported")
+    expect(browserProfileCommandKind("browser-6")).toBe("unsupported")
+    expect(browserProfileCommandKind("project-browser-6")).toBe("unrelated")
+    expect(() => browserProfileFromCommand("browser-6")).toThrow(
+      "Invalid browser profile '6'. Use cyberful browser-1 through cyberful browser-5.",
+    )
+    expect(invalidBrowserProfileMessage("browser-account")).toBe(
+      "Invalid browser profile 'account'. Use cyberful browser-1 through cyberful browser-5.",
+    )
+  })
+})

--- a/cyberful/src/cli/cmd/browser.ts
+++ b/cyberful/src/cli/cmd/browser.ts
@@ -1,0 +1,50 @@
+// ── Browser Profile CLI Command ──────────────────────────────────────
+// Exposes the five persistent browser identities through browser-1…browser-5
+// and renders launch failures without revealing browser-profile contents.
+// → cyberful/src/dependency/browser-profile-launcher.ts — owns the browser child.
+// @docs/user-guide/interface.md
+// @docs/runtimes/browser.md
+// ─────────────────────────────────────────────────────────────────────
+
+import type { CommandModule } from "yargs"
+import { BrowserProfile, type BrowserProfileId } from "@/dependency/browser-profile"
+import { BrowserProfileLauncher } from "@/dependency/browser-profile-launcher"
+import { UI } from "../ui"
+import { errorMessage } from "@/util/error"
+
+export const BROWSER_PROFILE_COMMANDS = BrowserProfile.BROWSER_PROFILE_IDS.map((profile) => `browser-${profile}`)
+
+export function browserProfileCommandKind(value: string): "supported" | "unsupported" | "unrelated" {
+  if (!value.startsWith("browser-")) return "unrelated"
+  return BROWSER_PROFILE_COMMANDS.includes(value) ? "supported" : "unsupported"
+}
+
+export function browserProfileFromCommand(value: unknown): BrowserProfileId {
+  if (typeof value !== "string") throw new Error("Browser profile command is missing")
+  const match = /^browser-(\d+)$/.exec(value)
+  const profile = match ? Number(match[1]) : Number.NaN
+  if (!BrowserProfile.isBrowserProfileId(profile)) throw new RangeError(invalidBrowserProfileMessage(value))
+  return profile
+}
+
+export function invalidBrowserProfileMessage(command: string): string {
+  const requested = command.startsWith("browser-") ? command.slice("browser-".length) : command
+  return `Invalid browser profile '${requested}'. Use cyberful browser-1 through cyberful browser-5.`
+}
+
+export const BrowserCommand = {
+  command: BROWSER_PROFILE_COMMANDS,
+  describe: "open a persistent browser profile for target pre-authentication",
+  builder: (yargs) => yargs,
+  handler: async (args) => {
+    const profile = browserProfileFromCommand(args._[0])
+    try {
+      const exitCode = await BrowserProfileLauncher.launchBrowserProfile(profile)
+      process.exitCode = exitCode
+      if (exitCode !== 0) UI.error(`Cyberful browser profile ${profile} exited with status ${exitCode}.`)
+    } catch (error) {
+      UI.error(`Could not open Cyberful browser profile ${profile}: ${errorMessage(error)}`)
+      process.exitCode = 1
+    }
+  },
+} satisfies CommandModule<object, object>

--- a/cyberful/src/dependency/browser-profile-launcher.test.ts
+++ b/cyberful/src/dependency/browser-profile-launcher.test.ts
@@ -1,0 +1,139 @@
+// ── Manual Browser Profile Launcher Tests ───────────────────────────
+// Verifies that the installed-command path selects one isolated identity and
+// waits for its real child process without downloading or opening Chromium.
+// → cyberful/src/dependency/browser-profile-launcher.ts — owns the tested child.
+// @docs/runtimes/browser.md
+// ─────────────────────────────────────────────────────────────────────
+
+import { afterEach, expect, test } from "bun:test"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+import { BrowserProfileLauncher } from "./browser-profile-launcher"
+
+const ENVIRONMENT_KEYS = [
+  "CYBERFUL_SKIP_BROWSER_PREFLIGHT",
+  "CYBER_BROWSER_MCP_COMMAND",
+  "CYBER_BROWSER_MCP_ENTRY",
+  "CYBER_BROWSER_BUN_REENTRY",
+  "CYBER_BROWSER_USER_DATA_DIR_3",
+  "CYBER_BROWSER_ARTIFACTS_DIR_3",
+  "CYBERFUL_TEST_BROWSER_RESULT",
+] as const
+const originalEnvironment = Object.fromEntries(ENVIRONMENT_KEYS.map((key) => [key, process.env[key]]))
+const temporaryRoots: string[] = []
+
+afterEach(() => {
+  ENVIRONMENT_KEYS.forEach((key) => {
+    const value = originalEnvironment[key]
+    if (value === undefined) delete process.env[key]
+    if (value !== undefined) process.env[key] = value
+  })
+  temporaryRoots.splice(0).forEach((root) => fs.rmSync(root, { recursive: true, force: true }))
+})
+
+test("the installed CLI opens the selected persistent browser identity and waits for exit", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "cyberful-browser-profile-"))
+  temporaryRoots.push(root)
+  const fixture = path.join(root, "browser-fixture.ts")
+  const result = path.join(root, "result.json")
+  await Bun.write(
+    fixture,
+    `await Bun.write(process.env.CYBERFUL_TEST_BROWSER_RESULT, JSON.stringify({
+      profile: process.env.CYBER_BROWSER_PROFILE_ID,
+      profileDirectory: process.env.CYBER_BROWSER_USER_DATA_DIR,
+      artifactsDirectory: process.env.CYBER_BROWSER_ARTIFACTS_DIR,
+      eager: process.env.CYBER_BROWSER_EAGER,
+      headless: process.env.CYBER_BROWSER_HEADLESS,
+      bunReentry: process.env.BUN_BE_BUN,
+    }))\n`,
+  )
+  Object.assign(process.env, {
+    CYBERFUL_SKIP_BROWSER_PREFLIGHT: "1",
+    CYBER_BROWSER_MCP_COMMAND: process.execPath,
+    CYBER_BROWSER_MCP_ENTRY: fixture,
+    CYBER_BROWSER_BUN_REENTRY: "1",
+    CYBER_BROWSER_USER_DATA_DIR_3: "/profiles/three",
+    CYBER_BROWSER_ARTIFACTS_DIR_3: "/artifacts/three",
+    CYBERFUL_TEST_BROWSER_RESULT: result,
+  })
+
+  expect(await BrowserProfileLauncher.launchBrowserProfile(3, { write: () => {} })).toBe(0)
+  expect(await Bun.file(result).json()).toEqual({
+    profile: "3",
+    profileDirectory: "/profiles/three",
+    artifactsDirectory: "/artifacts/three",
+    eager: "1",
+    headless: "false",
+    bunReentry: "1",
+  })
+})
+
+test.skipIf(process.platform === "win32")(
+  "terminal termination reaches the browser and waits for clean exit",
+  async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "cyberful-browser-signal-"))
+    temporaryRoots.push(root)
+    const browserFixture = path.join(root, "browser-fixture.ts")
+    const launcherFixture = path.join(root, "launcher-fixture.ts")
+    const ready = path.join(root, "ready")
+    const received = path.join(root, "received")
+    await Promise.all([
+      Bun.write(
+        browserFixture,
+        `await Bun.write(process.env.CYBERFUL_TEST_BROWSER_READY, "ready")
+process.once("SIGTERM", async () => {
+  await Bun.write(process.env.CYBERFUL_TEST_BROWSER_SIGNAL, "SIGTERM")
+  process.exit(0)
+})
+await new Promise(() => {})
+`,
+      ),
+      Bun.write(
+        launcherFixture,
+        `import { launchBrowserProfile } from ${JSON.stringify(
+          pathToFileURL(path.join(import.meta.dir, "browser-profile-launcher.ts")).href,
+        )}
+process.exitCode = await launchBrowserProfile(4, { write: () => {} })
+`,
+      ),
+    ])
+    const parent = Bun.spawn([process.execPath, launcherFixture], {
+      env: {
+        ...process.env,
+        CYBERFUL_SKIP_BROWSER_PREFLIGHT: "1",
+        CYBER_BROWSER_MCP_COMMAND: process.execPath,
+        CYBER_BROWSER_MCP_ENTRY: browserFixture,
+        CYBER_BROWSER_BUN_REENTRY: "1",
+        CYBER_BROWSER_USER_DATA_DIR_4: path.join(root, "profile"),
+        CYBER_BROWSER_ARTIFACTS_DIR_4: path.join(root, "artifacts"),
+        CYBERFUL_TEST_BROWSER_READY: ready,
+        CYBERFUL_TEST_BROWSER_SIGNAL: received,
+      },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    try {
+      const deadline = Date.now() + 5_000
+      while (!fs.existsSync(ready)) {
+        if (Date.now() >= deadline) throw new Error("browser fixture did not become ready")
+        await Bun.sleep(10)
+      }
+      parent.kill("SIGTERM")
+      const exitCode = await Promise.race([
+        parent.exited,
+        Bun.sleep(5_000).then(() => {
+          throw new Error("browser launcher did not reap its terminated child")
+        }),
+      ])
+      expect(exitCode).toBe(0)
+      expect(await Bun.file(received).text()).toBe("SIGTERM")
+    } finally {
+      if (parent.exitCode === null) parent.kill("SIGKILL")
+      await parent.exited
+    }
+  },
+)

--- a/cyberful/src/dependency/browser-profile-launcher.ts
+++ b/cyberful/src/dependency/browser-profile-launcher.ts
@@ -1,0 +1,70 @@
+// ── Manual Browser Profile Process Ownership ────────────────────────
+// Starts one selected persistent browser identity, keeps the terminal attached,
+// and owns signal forwarding until the embedded or source browser process exits.
+// → cyberful/src/dependency/browser-profile.ts — resolves isolated profile state.
+// → cyberful/src/dependency/browser-preflight.ts — installs Chromium before launch.
+// @docs/runtimes/browser.md
+// ─────────────────────────────────────────────────────────────────────
+
+import { BrowserPreflight } from "./browser-preflight"
+import { cyberBrowserMcpCommand } from "./config"
+import { BrowserProfile, type BrowserProfileId } from "./browser-profile"
+
+const FORWARDED_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const
+
+export interface BrowserProfileLaunchOptions {
+  readonly write?: (message: string) => void
+}
+
+// ── The CLI Owns The Interactive Browser Lifetime ───────────────────
+// Eager browser mode opens the persistent context and intentionally waits while
+// its Chromium window remains alive. The CLI therefore inherits the terminal,
+// forwards every ordinary termination signal, and awaits the child after normal
+// close or interruption. Signal listeners are removed only after that process is
+// reaped, preventing a completed profile session from affecting later CLI work.
+// ─────────────────────────────────────────────────────────────────────
+export async function launchBrowserProfile(
+  profile: BrowserProfileId,
+  options: BrowserProfileLaunchOptions = {},
+): Promise<number> {
+  await BrowserPreflight.runBrowserPreflight()
+
+  const write = options.write ?? ((message: string) => process.stderr.write(message))
+  const profileDirectory = BrowserProfile.browserProfileDir(profile)
+  write(`Opening Cyberful browser profile ${profile}: ${profileDirectory}\n`)
+  write("Sign in to the authorized target, then close the browser before starting Cyberful.\n")
+
+  const child = Bun.spawn(cyberBrowserMcpCommand(), {
+    env: {
+      ...BrowserProfile.manualBrowserProfileEnv(profile),
+      ...(process.env.CYBER_BROWSER_BUN_REENTRY === "1" ? { BUN_BE_BUN: "1" } : {}),
+    },
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  })
+  const forwarders = new Map(
+    FORWARDED_SIGNALS.map(
+      (signal) =>
+        [
+          signal,
+          () => {
+            try {
+              child.kill(signal)
+            } catch {
+              // The browser may already have released its profile lock and exited.
+            }
+          },
+        ] as const,
+    ),
+  )
+
+  forwarders.forEach((forward, signal) => process.on(signal, forward))
+  try {
+    return await child.exited
+  } finally {
+    forwarders.forEach((forward, signal) => process.removeListener(signal, forward))
+  }
+}
+
+export * as BrowserProfileLauncher from "./browser-profile-launcher"

--- a/cyberful/src/dependency/browser-profile.test.ts
+++ b/cyberful/src/dependency/browser-profile.test.ts
@@ -61,6 +61,7 @@ describe("browser profile identity", () => {
       PATH: "/usr/bin",
       CYBER_BROWSER_BROWSERS_PATH: "/home/tester/.cyberful/browser/.browsers",
       CYBER_BROWSER_USER_DATA_DIR: "/profiles/two",
+      CYBER_BROWSER_ARTIFACTS_DIR: "/home/tester/.cyberful/browser/artifacts/profile-2",
       CYBER_BROWSER_PROFILE_ID: "2",
       CYBER_BROWSER_EAGER: "1",
       CYBER_BROWSER_HEADLESS: "false",

--- a/cyberful/src/dependency/browser-profile.ts
+++ b/cyberful/src/dependency/browser-profile.ts
@@ -83,6 +83,7 @@ export function manualBrowserProfileEnv(
     CYBER_BROWSER_BROWSERS_PATH:
       configuredPath(env, "CYBER_BROWSER_BROWSERS_PATH") ?? path.join(browserHome(homeDirectory), ".browsers"),
     CYBER_BROWSER_USER_DATA_DIR: browserProfileDir(profile, env, homeDirectory),
+    CYBER_BROWSER_ARTIFACTS_DIR: browserArtifactsDir(profile, env, homeDirectory),
     CYBER_BROWSER_PROFILE_ID: String(profile),
     CYBER_BROWSER_EAGER: "1",
     CYBER_BROWSER_HEADLESS: "false",

--- a/cyberful/src/index.ts
+++ b/cyberful/src/index.ts
@@ -34,6 +34,7 @@ import { EOL } from "os"
 import { SessionCommand } from "./cli/cmd/session"
 import { ApprovalCommand } from "./cli/cmd/approval"
 import { AuthCommand } from "./cli/cmd/auth"
+import { BrowserCommand, browserProfileCommandKind, invalidBrowserProfileMessage } from "./cli/cmd/browser"
 import { bootstrapConfigReady } from "./bootstrap-config"
 import { bootstrapBrowserReady } from "./bootstrap-browser"
 import { GATEWAY_ARGV } from "./subsystem/gateway/config"
@@ -95,6 +96,11 @@ if (process.argv.includes(GATEWAY_ARGV)) {
 }
 
 const args = hideBin(process.argv)
+const requestedBrowserCommand = args[0]
+if (requestedBrowserCommand && browserProfileCommandKind(requestedBrowserCommand) === "unsupported") {
+  UI.error(invalidBrowserProfileMessage(requestedBrowserCommand))
+  process.exit(2)
+}
 
 function show(out: string) {
   const text = out.trimStart()
@@ -215,6 +221,7 @@ const cli = yargs(args)
   .command(SessionCommand)
   .command(ApprovalCommand)
   .command(AuthCommand)
+  .command(BrowserCommand)
   .fail((msg, err) => {
     if (
       msg?.startsWith("Unknown argument") ||

--- a/docs/runtimes/browser.md
+++ b/docs/runtimes/browser.md
@@ -35,16 +35,22 @@ those identities to `profile: 1` and `profile: 2` on every browser call.
 
 ## Pre-authenticate profiles manually
 
-From the repository root, open the identity you want to seed:
+From a global npm installation, open the identity you want to seed:
 
 ```sh
-make browser-run-1
-make browser-run-2
-# ...through make browser-run-5
+cyberful browser-1
+cyberful browser-2
+# ...through cyberful browser-5
 ```
 
+The command installs the isolated Chromium build when necessary, opens the same
+persistent profile used during tests, and remains attached until the browser is
+closed or the command is interrupted. Invalid or unavailable profile numbers
+fail with a non-zero status. Source contributors can use the equivalent
+`make browser-run-1` through `make browser-run-5` targets.
+
 Sign in only to the authorized target account for that identity, then fully
-close the Chromium window. The Make command returns after the browser exits and
+close the Chromium window. The command returns after the browser exits and
 releases its profile lock. Repeat for other accounts, then run Cyberful and tell
 it which account is stored in each numbered profile. Do not leave a manual
 profile open when starting Cyberful: a locked profile is replaced with a

--- a/docs/user-guide/interface.md
+++ b/docs/user-guide/interface.md
@@ -5,6 +5,21 @@ first prompt before opening a persisted session. The terminal layout remains
 usable at different window sizes and keeps transient menus in front of the
 controls they describe.
 
+## Prepare a browser profile
+
+Use `cyberful browser-1` through `cyberful browser-5` to open one isolated,
+persistent browser identity before a test. The command works from the global npm
+installation, provisions Chromium when necessary, and stays attached until the
+window closes or the terminal command is interrupted. Fully close the window
+before starting Cyberful so the test can acquire that profile without replacing
+it with a temporary unauthenticated fallback.
+
+Each number retains separate cookies, local storage, cache, tabs, and downloads.
+Use only the authorized target account assigned to that identity; the command
+never opens a personal browser profile. An invalid number or a profile that
+cannot be started returns a non-zero status with a terminal error. See the
+[browser runtime](../runtimes/browser.md) for storage paths and configuration.
+
 ## Appearance and light mode
 
 Cyberful uses its built-in color theme; custom theme files, installation, and


### PR DESCRIPTION
## Summary

- expose `cyberful browser-1` through `cyberful browser-5` from the globally installed CLI
- share preflight, persistent profile selection, attached child lifetime, and signal forwarding with the source Make targets
- keep browser artifacts isolated per profile and return clear failures for unsupported profile identifiers
- document the installed workflow in the README and engineer/user guides

Closes #33

## Verification

- `make typecheck`
- `bun run --cwd cyberful test` — 770 passed
- targeted browser-profile CLI and real SIGTERM-forwarding tests — 7 passed
- browser MCP suite — 24 passed
- `make docs-build`
- standalone release build
- offline global npm package installation with valid and invalid command smoke tests

## Security and release impact

- [x] The change stays within Cyberful's authorization and no-telemetry boundaries.
- [x] No credentials, engagement data, transcripts, reports, browser profiles, or runtime state are included.
- [x] Tests cover behavior changes and documentation is updated where required.
- [x] No new dependencies or redistributed assets are introduced.
