### PR TITLE
Remove draft release visibility race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -463,6 +463,7 @@ jobs:
         run: >-
           bun scripts/upload-release-assets.ts
           --tag "v$RELEASE_VERSION"
+          --release-id "${{ steps.release.outputs.release_id }}"
           --directory release-assets
 
   publish-npm:

--- a/cyberful/script/upload-release-assets.test.ts
+++ b/cyberful/script/upload-release-assets.test.ts
@@ -8,7 +8,7 @@ import { afterEach, describe, expect, test } from "bun:test"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
-import { githubReleaseByTag } from "../../scripts/upload-release-assets"
+import { githubReleaseById, githubReleaseByTag } from "../../scripts/upload-release-assets"
 
 const temporaryRoots: string[] = []
 
@@ -26,6 +26,27 @@ function fakeGitHub(pages: unknown) {
 }
 
 describe("draft release recovery", () => {
+  test("resolves the creation response ID without waiting for list visibility", () => {
+    const release = githubReleaseById(
+      "cyberful/cyberful",
+      "v0.2.0",
+      367282802,
+      fakeGitHub({
+        id: 367282802,
+        tag_name: "v0.2.0",
+        draft: true,
+        upload_url: "https://uploads.github.com/repos/cyberful/cyberful/releases/367282802/assets{?name,label}",
+        assets: [],
+      }),
+    )
+
+    expect(release).toEqual({
+      id: 367282802,
+      uploadUrl: "https://uploads.github.com/repos/cyberful/cyberful/releases/367282802/assets",
+      assets: [],
+    })
+  })
+
   test("resolves an authenticated draft by tag and stable release ID", () => {
     const release = githubReleaseByTag(
       "cyberful/cyberful",

--- a/scripts/upload-release-assets.ts
+++ b/scripts/upload-release-assets.ts
@@ -42,6 +42,65 @@ async function sha256(file: string) {
 type GitHubAsset = { id: number; name: string; digest?: string | null }
 type GitHubRelease = { id: number; uploadUrl: string; assets: GitHubAsset[] }
 
+function validateRelease(repository: string, tag: string, value: unknown): GitHubRelease {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("id" in value) ||
+    !Number.isSafeInteger(value.id) ||
+    Number(value.id) <= 0 ||
+    !("tag_name" in value) ||
+    value.tag_name !== tag ||
+    !("upload_url" in value) ||
+    typeof value.upload_url !== "string" ||
+    !("assets" in value) ||
+    !Array.isArray(value.assets)
+  ) {
+    throw new Error(`GitHub Release ${tag} returned an invalid release record`)
+  }
+  const uploadUrl = value.upload_url.replace(/\{\?name,label\}$/, "")
+  if (uploadUrl !== `https://uploads.github.com/repos/${repository}/releases/${value.id}/assets`) {
+    throw new Error(`GitHub Release ${tag} returned an invalid upload URL`)
+  }
+  const assets = value.assets.filter(
+    (asset): asset is GitHubAsset =>
+      typeof asset === "object" &&
+      asset !== null &&
+      "id" in asset &&
+      Number.isSafeInteger(asset.id) &&
+      Number(asset.id) > 0 &&
+      "name" in asset &&
+      typeof asset.name === "string" &&
+      (!("digest" in asset) || asset.digest === null || typeof asset.digest === "string"),
+  )
+  if (assets.length !== value.assets.length) throw new Error(`GitHub Release ${tag} returned an invalid asset record`)
+  if (new Set(assets.map((asset) => asset.name)).size !== assets.length) {
+    throw new Error(`GitHub Release ${tag} returned duplicate asset names`)
+  }
+  return { id: Number(value.id), uploadUrl, assets }
+}
+
+export function githubReleaseById(repository: string, tag: string, releaseId: number, ghExecutable = "gh") {
+  if (!Number.isSafeInteger(releaseId) || releaseId <= 0) throw new Error("GitHub Release ID must be a positive integer")
+  const lookup = Bun.spawnSync([ghExecutable, "api", `repos/${repository}/releases/${releaseId}`], {
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 60_000,
+    maxBuffer: 16_777_216,
+  })
+  if (lookup.exitCode !== 0) {
+    const detail = new TextDecoder().decode(lookup.stderr).trim().slice(0, 2_000)
+    throw new Error(`Cannot inspect GitHub Release ${tag}${detail ? `: ${detail}` : ""}`)
+  }
+  const release = validateRelease(
+    repository,
+    tag,
+    parseJson(new TextDecoder().decode(lookup.stdout), `GitHub Release ${tag}`),
+  )
+  if (release.id !== releaseId) throw new Error(`GitHub Release ${tag} returned the wrong release ID`)
+  return release
+}
+
 // ── Draft Releases Require Authenticated List Resolution ───────────
 // GitHub's release-by-tag endpoint exposes public releases but returns 404 for
 // an authenticated draft, whose browser URL uses a temporary `untagged-*` name.
@@ -75,39 +134,12 @@ export function githubReleaseByTag(repository: string, tag: string, ghExecutable
     )
   if (matches.length === 0) return
   if (matches.length > 1) throw new Error(`GitHub returned multiple releases for ${tag}`)
-  const release = matches[0]
-  if (
-    !Number.isSafeInteger(release.id) ||
-    Number(release.id) <= 0 ||
-    typeof release.upload_url !== "string" ||
-    !Array.isArray(release.assets)
-  ) {
-    throw new Error(`GitHub Release ${tag} returned an invalid release record`)
-  }
-  const uploadUrl = release.upload_url.replace(/\{\?name,label\}$/, "")
-  if (uploadUrl !== `https://uploads.github.com/repos/${repository}/releases/${release.id}/assets`) {
-    throw new Error(`GitHub Release ${tag} returned an invalid upload URL`)
-  }
-  const assets = release.assets.filter(
-    (asset): asset is GitHubAsset =>
-      typeof asset === "object" &&
-      asset !== null &&
-      "id" in asset &&
-      Number.isSafeInteger(asset.id) &&
-      Number(asset.id) > 0 &&
-      "name" in asset &&
-      typeof asset.name === "string" &&
-      (!("digest" in asset) || asset.digest === null || typeof asset.digest === "string"),
-  )
-  if (assets.length !== release.assets.length) throw new Error(`GitHub Release ${tag} returned an invalid asset record`)
-  if (new Set(assets.map((asset) => asset.name)).size !== assets.length) {
-    throw new Error(`GitHub Release ${tag} returned duplicate asset names`)
-  }
-  return { id: Number(release.id), uploadUrl, assets } satisfies GitHubRelease
+  return validateRelease(repository, tag, matches[0])
 }
 
 if (import.meta.main) {
   const tag = argument("--tag")
+  const releaseIdArgument = argument("--release-id")
   const directoryArgument = argument("--directory")
   const repository = process.env.GITHUB_REPOSITORY?.trim()
   if (!tag || !tag.startsWith("v") || !semver.valid(tag.slice(1))) {
@@ -117,9 +149,15 @@ if (import.meta.main) {
   if (!repository || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
     throw new Error("GITHUB_REPOSITORY must be an owner/repository pair")
   }
+  const releaseId = releaseIdArgument === undefined ? undefined : Number(releaseIdArgument)
+  if (releaseId !== undefined && (!Number.isSafeInteger(releaseId) || releaseId <= 0)) {
+    throw new Error("--release-id must be a positive integer")
+  }
   const directory = path.resolve(directoryArgument)
   if (!fs.statSync(directory, { throwIfNoEntry: false })?.isDirectory()) throw new Error("--directory is required")
-  const release = githubReleaseByTag(repository, tag)
+  const release = releaseId === undefined
+    ? githubReleaseByTag(repository, tag)
+    : githubReleaseById(repository, tag, releaseId)
   if (!release) throw new Error(`GitHub Release ${tag} does not exist`)
 
   for (const entry of fs


### PR DESCRIPTION
## Summary

- pass the numeric release ID returned by the draft creation boundary directly to the asset uploader
- resolve and validate the exact draft by ID instead of waiting for GitHub release-list propagation
- retain tag-list discovery for resumptions and its existing bounded retry/backoff path
- cover the immediately-created-but-not-list-visible case with a regression test

## Verification

- `bun test script/upload-release-assets.test.ts`: 3 pass, 0 fail
- `make typecheck`
- `git diff --check`

## Incident context

The first `v0.2.0` staging attempt created draft release `367282802`, then an immediate authenticated list read temporarily returned no match. Re-running the failed jobs succeeded after propagation. This change removes that normal-path race.