### PR TITLE
Resume oversized npm releases safely

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,9 @@
+# ── Stable Release Publication ──────────────────────────────────────
+# Verifies, builds, stages, and publishes one immutable native Cyberful release,
+# including an integrity-checked recovery path for a partially published version.
+# @docs/development/release.md
+# ────────────────────────────────────────────────────────────────────
+
 name: Release
 
 on:
@@ -13,6 +19,11 @@ on:
         required: true
         default: true
         type: boolean
+      resume_run_id:
+        description: Failed Release run ID whose staged artifacts should resume
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   group: npm-stable-release
@@ -29,6 +40,7 @@ env:
 jobs:
   verify:
     name: Verify release input and source
+    if: inputs.resume_run_id == ''
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
@@ -485,10 +497,167 @@ jobs:
           echo "GitHub Release $TAG was not published and locked as immutable." >&2
           exit 1
 
+  resume-release:
+    name: Resume npm and publish release
+    if: inputs.resume_run_id != '' && inputs.dry_run != true
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      actions: read # Download the exact staged artifact from the failed release run.
+      contents: write # Reconcile the draft assets and publish the existing release.
+      id-token: write # Authenticate npm trusted publishing through GitHub OIDC.
+    env:
+      RELEASE_VERSION: ${{ inputs.version }}
+      RESUME_RUN_ID: ${{ inputs.resume_run_id }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.1.2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6.1.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - run: npm install --global "npm@${NPM_VERSION}"
+      - run: bun install --frozen-lockfile
+      - id: release
+        name: Require the failed run, original tag, and draft release
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+          TAG: v${{ inputs.version }}
+        shell: bash
+        run: |
+          if [[ "$DEFAULT_BRANCH" != main || "$GITHUB_REF" != refs/heads/main ]]; then
+            echo "Release recovery requires refs/heads/main and main must be the default branch." >&2
+            exit 1
+          fi
+          [[ "$RESUME_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          test "$RESUME_RUN_ID" != "$GITHUB_RUN_ID"
+          bun -e 'import semver from "semver"; const version = process.env.RELEASE_VERSION ?? ""; if (!semver.valid(version) || semver.prerelease(version)) throw new Error(`Release version must be stable SemVer: ${version || "<empty>"}`)'
+
+          workflow_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/release.yml" --jq .id)"
+          run_state="$(
+            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RESUME_RUN_ID" \
+              --jq '[.workflow_id, .event, .status, .conclusion, .head_branch, .head_sha] | @tsv'
+          )"
+          IFS=$'\t' read -r run_workflow run_event run_status run_conclusion run_branch run_sha <<< "$run_state"
+          test "$run_workflow" = "$workflow_id"
+          test "$run_event" = workflow_dispatch
+          test "$run_status" = completed
+          test "$run_conclusion" = failure
+          test "$run_branch" = main
+          [[ "$run_sha" =~ ^[0-9a-f]{40}$ ]]
+
+          test "$(git cat-file -t "refs/tags/$TAG")" = tag
+          test "$(git rev-parse "$TAG^{commit}")" = "$run_sha"
+          latest="$(git tag --list 'v*' | bun -e 'import semver from "semver"; const tags = (await Bun.stdin.text()).split(/\s+/).filter(Boolean).filter((tag) => semver.valid(tag.slice(1)) && !semver.prerelease(tag.slice(1))).sort((left, right) => semver.rcompare(left.slice(1), right.slice(1))); if (tags[0]) process.stdout.write(tags[0])')"
+          test "$latest" = "$TAG"
+
+          release_ids="$(
+            gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+              --jq ".[] | select(.tag_name == \"$TAG\") | .id"
+          )"
+          if [[ "$release_ids" == *$'\n'* || ! "$release_ids" =~ ^[0-9]+$ ]]; then
+            echo "Expected exactly one draft GitHub Release for $TAG." >&2
+            exit 1
+          fi
+          release_state="$(
+            gh api "repos/$GITHUB_REPOSITORY/releases/$release_ids" \
+              --jq '[.tag_name, (.draft | tostring)] | @tsv'
+          )"
+          test "$release_state" = "$TAG"$'\ttrue'
+          echo "release_id=$release_ids" >> "$GITHUB_OUTPUT"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          name: release-v${{ inputs.version }}
+          path: release-assets
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.resume_run_id }}
+      - name: Recompress the oversized npm package without changing its tar payload
+        env:
+          PACKAGE_ASSET: cyberful-org-cyberful-linux-x64-${{ inputs.version }}.tgz
+        shell: bash
+        run: |
+          bun scripts/optimize-npm-package.ts --file "release-assets/$PACKAGE_ASSET"
+          bun scripts/write-checksums.ts release-assets
+      - name: Reconcile only the recompressed draft assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE_ASSET: cyberful-org-cyberful-linux-x64-${{ inputs.version }}.tgz
+          RELEASE_ID: ${{ steps.release.outputs.release_id }}
+          TAG: v${{ inputs.version }}
+        shell: bash
+        run: |
+          # ── Recovery Mutates Only Two Named Draft Assets ─────────────
+          # The failed run already staged a complete draft whose other files must
+          # remain byte-identical. Recovery permits replacement only for the npm
+          # tarball whose deflate stream changed and the checksum manifest that
+          # records that new digest. Matching retries preserve both assets, while
+          # any mismatch elsewhere still fails closed in the uploader below.
+          # ─────────────────────────────────────────────────────────────
+          for asset_name in "$PACKAGE_ASSET" SHA256SUMS; do
+            local_digest="sha256:$(sha256sum "release-assets/$asset_name" | cut -d' ' -f1)"
+            asset_record="$(
+              gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+                --jq ".assets[] | select(.name == \"$asset_name\") | [.id, .digest] | @tsv"
+            )"
+            if [[ "$asset_record" == *$'\n'* || -z "$asset_record" ]]; then
+              echo "Expected exactly one staged asset named $asset_name." >&2
+              exit 1
+            fi
+            IFS=$'\t' read -r asset_id remote_digest <<< "$asset_record"
+            [[ "$asset_id" =~ ^[0-9]+$ ]]
+            [[ "$remote_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+            if [[ "$remote_digest" = "$local_digest" ]]; then
+              continue
+            fi
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id" --silent
+          done
+          bun scripts/upload-release-assets.ts \
+            --tag "$TAG" \
+            --release-id "$RELEASE_ID" \
+            --directory release-assets
+      - name: Publish missing npm packages, then the launcher
+        shell: bash
+        run: >-
+          bun scripts/publish-npm.ts
+          --directory release-assets
+          --version "$RELEASE_VERSION"
+      - name: Publish the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ steps.release.outputs.release_id }}
+          TAG: v${{ inputs.version }}
+        shell: bash
+        run: |
+          gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            -F draft=false \
+            -f make_latest=true \
+            --silent
+          for attempt in {1..12}; do
+            state="$(
+              gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+                --jq '[.tag_name, (.draft | tostring), (.immutable | tostring)] | @tsv'
+            )"
+            if [[ "$state" = "$TAG"$'\tfalse\ttrue' ]]; then
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "GitHub Release $TAG was not published and locked as immutable." >&2
+          exit 1
+
   required:
     name: Release required
     if: always()
-    needs: [verify, build, assemble, stage-release, publish-npm, publish-release]
+    needs: [verify, build, assemble, stage-release, publish-npm, publish-release, resume-release]
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -496,6 +665,8 @@ jobs:
       - name: Require the selected release path
         env:
           DRY_RUN: ${{ inputs.dry_run }}
+          RESUME_RUN_ID: ${{ inputs.resume_run_id }}
+          RESUME_RESULT: ${{ needs.resume-release.result }}
           VERIFY_RESULT: ${{ needs.verify.result }}
           BUILD_RESULT: ${{ needs.build.result }}
           ASSEMBLE_RESULT: ${{ needs.assemble.result }}
@@ -504,6 +675,11 @@ jobs:
           RELEASE_RESULT: ${{ needs.publish-release.result }}
         shell: bash
         run: |
+          if [[ -n "$RESUME_RUN_ID" ]]; then
+            test "$DRY_RUN" != true
+            test "$RESUME_RESULT" = success
+            exit 0
+          fi
           test "$VERIFY_RESULT" = success
           test "$BUILD_RESULT" = success
           test "$ASSEMBLE_RESULT" = success

--- a/bun.lock
+++ b/bun.lock
@@ -74,6 +74,7 @@
         "yauzl": "3.2.0",
       },
       "devDependencies": {
+        "@gfx/zopfli": "1.0.15",
         "@hey-api/openapi-ts": "0.99.0",
         "@parcel/watcher-darwin-arm64": "2.5.1",
         "@parcel/watcher-darwin-x64": "2.5.1",
@@ -328,6 +329,8 @@
     "@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
     "@gar/promise-retry": ["@gar/promise-retry@1.0.3", "", {}, "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA=="],
+
+    "@gfx/zopfli": ["@gfx/zopfli@1.0.15", "", { "dependencies": { "base64-js": "^1.3.0" } }, "sha512-7mBgpi7UD82fsff5ThQKet0uBTl4BYerQuc+/qA1ELTwWEiIedRTcD3JgiUu9wwZ2kytW8JOb165rSdAt8PfcQ=="],
 
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
@@ -689,7 +692,7 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="],
 
@@ -1581,11 +1584,7 @@
 
     "babel-plugin-module-resolver/glob": ["glob@9.3.5", "", { "dependencies": { "fs.realpath": "^1.0.0", "minimatch": "^8.0.2", "minipass": "^4.2.4", "path-scurry": "^1.6.1" } }, "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q=="],
 
-    "brotli/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
-
     "browserify-zlib/pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
-
-    "buffer/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
@@ -1599,7 +1598,7 @@
 
     "global-agent/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
-    "google-auth-library/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+    "linebreak/base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
 
     "minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
@@ -1638,8 +1637,6 @@
     "string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
-
-    "unicode-properties/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 

--- a/cyberful/package.json
+++ b/cyberful/package.json
@@ -37,6 +37,7 @@
     "./*": "./src/*.ts"
   },
   "devDependencies": {
+    "@gfx/zopfli": "1.0.15",
     "@hey-api/openapi-ts": "0.99.0",
     "@parcel/watcher-darwin-arm64": "2.5.1",
     "@parcel/watcher-darwin-x64": "2.5.1",

--- a/cyberful/script/package-npm.test.ts
+++ b/cyberful/script/package-npm.test.ts
@@ -8,7 +8,15 @@ import { afterEach, describe, expect, test } from "bun:test"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
-import { metaManifest, packNpmPackage, platformManifest, stageMetaPackage, stagePlatformPackage } from "./package-npm"
+import { gunzipSync, gzipSync } from "node:zlib"
+import {
+  metaManifest,
+  optimizeNpmPackage,
+  packNpmPackage,
+  platformManifest,
+  stageMetaPackage,
+  stagePlatformPackage,
+} from "./package-npm"
 
 const temporaryRoots: string[] = []
 
@@ -134,5 +142,41 @@ describe("npm package staging", () => {
       "cannot replace the repository root",
     )
     expect(fs.readFileSync(path.join(repositoryRoot, "LICENSE"), "utf8")).toBe("AGPL-3.0-only")
+  })
+})
+
+describe("npm package upload size", () => {
+  test("recompresses an oversized archive without changing its tar payload", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "cyberful-npm-compression-"))
+    temporaryRoots.push(root)
+    const file = path.join(root, "package.tgz")
+    const tar = Buffer.from("cyberful-release-payload\n".repeat(100_000))
+    const original = gzipSync(tar, { level: 1 })
+    fs.writeFileSync(file, original)
+
+    const result = await optimizeNpmPackage(file, {
+      compressionThresholdBytes: 1,
+      uploadLimitBytes: original.byteLength,
+    })
+
+    expect(result.optimized).toBeTrue()
+    expect(result.bytes).toBeLessThan(original.byteLength)
+    const first = fs.readFileSync(file)
+    expect(gunzipSync(first)).toEqual(tar)
+
+    fs.writeFileSync(file, original)
+    await optimizeNpmPackage(file, { compressionThresholdBytes: 1, uploadLimitBytes: original.byteLength })
+    expect(fs.readFileSync(file)).toEqual(first)
+  })
+
+  test("rejects a package that still exceeds the upload limit", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "cyberful-npm-limit-"))
+    temporaryRoots.push(root)
+    const file = path.join(root, "package.tgz")
+    fs.writeFileSync(file, gzipSync(Buffer.from("cyberful")))
+
+    await expect(optimizeNpmPackage(file, { compressionThresholdBytes: 1, uploadLimitBytes: 1 })).rejects.toThrow(
+      "remains above",
+    )
   })
 })

--- a/cyberful/script/package-npm.ts
+++ b/cyberful/script/package-npm.ts
@@ -6,9 +6,12 @@
 // @docs/development/release.md
 // ────────────────────────────────────────────────────────────────────
 
+import crypto from "node:crypto"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
+import { gunzipSync } from "node:zlib"
+import { gzipAsync } from "@gfx/zopfli"
 import semver from "semver"
 
 export type NpmPlatform = "darwin" | "linux" | "windows"
@@ -24,6 +27,9 @@ const publicPackages = [
   "@cyberful-org/cyberful-windows-x64",
 ]
 const publicTargets = new Set(["darwin-arm64", "darwin-x64", "linux-x64", "windows-x64"])
+const npmCompressionThresholdBytes = 250_000_000
+const npmUploadLimitBytes = 256_000_000
+const maximumUnpackedTarBytes = 1_500_000_000
 const releaseNotices = [
   ["THIRD_PARTY_NOTICES.md", "THIRD_PARTY_NOTICES.md"],
   ["cyberful/src/tool/assets/fonts/EB_GARAMOND_OFL.txt", "licenses/EB_GARAMOND_OFL.txt"],
@@ -216,6 +222,69 @@ export function packNpmPackage(directory: string, destination: string) {
   }
 }
 
+// ── Large Packages Preserve Their Exact Tar Payload ────────────────
+// npm rejects compressed uploads near 256 MB even when every declared file is
+// valid. npm pack already uses gzip level 9, so oversized platform packages are
+// recompressed deterministically with one Zopfli iteration while retaining the
+// exact tar bytes. A bounded inflate plus a post-compression digest check makes
+// archive corruption or an unexpectedly large input fail before publication.
+// ────────────────────────────────────────────────────────────────────
+export async function optimizeNpmPackage(
+  file: string,
+  options: { compressionThresholdBytes?: number; uploadLimitBytes?: number } = {},
+) {
+  const packageFile = path.resolve(file)
+  const source = fs.statSync(packageFile, { throwIfNoEntry: false })
+  if (!source?.isFile() || !packageFile.endsWith(".tgz")) throw new Error("An npm .tgz package is required")
+  const compressionThresholdBytes = options.compressionThresholdBytes ?? npmCompressionThresholdBytes
+  const uploadLimitBytes = options.uploadLimitBytes ?? npmUploadLimitBytes
+  if (!Number.isSafeInteger(compressionThresholdBytes) || compressionThresholdBytes <= 0) {
+    throw new Error("The npm compression threshold must be a positive integer")
+  }
+  if (!Number.isSafeInteger(uploadLimitBytes) || uploadLimitBytes <= 0) {
+    throw new Error("The npm upload limit must be a positive integer")
+  }
+  if (source.size < compressionThresholdBytes) {
+    return { bytes: source.size, optimized: false }
+  }
+
+  const original = Buffer.from(await Bun.file(packageFile).arrayBuffer())
+  let tar: Buffer
+  try {
+    tar = gunzipSync(original, { maxOutputLength: maximumUnpackedTarBytes })
+  } catch (error) {
+    throw new Error(`Cannot inflate npm package ${packageFile}`, { cause: error })
+  }
+  const tarDigest = crypto.createHash("sha256").update(tar).digest("hex")
+  const optimized = Buffer.from(await gzipAsync(tar, { numiterations: 1 }))
+  let restored: Buffer
+  try {
+    restored = gunzipSync(optimized, { maxOutputLength: maximumUnpackedTarBytes })
+  } catch (error) {
+    throw new Error(`Cannot verify optimized npm package ${packageFile}`, { cause: error })
+  }
+  if (
+    restored.byteLength !== tar.byteLength ||
+    crypto.createHash("sha256").update(restored).digest("hex") !== tarDigest
+  ) {
+    throw new Error(`Optimized npm package changed the tar payload: ${packageFile}`)
+  }
+  const selected = optimized.byteLength < original.byteLength ? optimized : original
+  if (selected.byteLength >= uploadLimitBytes) {
+    throw new Error(`npm package remains above the ${uploadLimitBytes}-byte upload limit: ${packageFile}`)
+  }
+  if (selected === original) return { bytes: original.byteLength, optimized: false }
+
+  const temporary = `${packageFile}.${crypto.randomUUID()}.tmp`
+  try {
+    await Bun.write(temporary, selected)
+    fs.renameSync(temporary, packageFile)
+  } finally {
+    fs.rmSync(temporary, { force: true })
+  }
+  return { bytes: selected.byteLength, optimized: true }
+}
+
 if (import.meta.main) {
   const repositoryRoot = path.resolve(import.meta.dir, "../..")
   const version = argument("--version") || process.env.CYBERFUL_VERSION?.trim() || ""
@@ -246,5 +315,6 @@ if (import.meta.main) {
     })
   }
   const artifact = packNpmPackage(staged, path.join(output, "packages"))
-  console.log(JSON.stringify({ artifact, staged }, null, 2))
+  const compression = await optimizeNpmPackage(artifact)
+  console.log(JSON.stringify({ artifact, compression, staged }, null, 2))
 }

--- a/scripts/optimize-npm-package.ts
+++ b/scripts/optimize-npm-package.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env bun
+// ── npm Release Artifact Optimization ───────────────────────────────
+// Applies the package assembler's bounded, byte-preserving compression policy
+// to one existing npm tarball so a staged partial release can resume safely.
+// → cyberful/script/package-npm.ts — owns the compression and integrity checks.
+// @docs/development/release.md
+// ────────────────────────────────────────────────────────────────────
+
+import path from "node:path"
+import { optimizeNpmPackage } from "../cyberful/script/package-npm"
+
+function argument(name: string) {
+  const indexes = Bun.argv.flatMap((value, index) => (value === name ? [index] : []))
+  if (indexes.length > 1) throw new Error(`${name} may be passed only once`)
+  if (indexes.length === 0) return
+  const value = Bun.argv[indexes[0] + 1]
+  if (!value || value.startsWith("--")) throw new Error(`${name} requires a value`)
+  return value
+}
+
+const file = argument("--file")
+if (!file) throw new Error("--file is required")
+const packageFile = path.resolve(file)
+const result = await optimizeNpmPackage(packageFile)
+console.log(JSON.stringify({ file: packageFile, ...result }, null, 2))


### PR DESCRIPTION
## Summary
- deterministically recompress npm tarballs above 250 MB while proving the uncompressed tar payload is unchanged
- add a guarded release resume path tied to the failed run, original annotated tag, and existing draft release
- preserve already-published npm package integrity and allow replacement of only the Linux tarball plus SHA256SUMS

## Verification
- `make test-bun` (1,046 application tests plus browser package checks)
- `bun run --cwd cyberful typecheck`
- 15 targeted release and package tests
- optimized tarball accepted by `npm publish --dry-run --ignore-scripts`
- workflow YAML and every Bash run block parsed successfully

## Security and release impact
- [x] The change stays within Cyberful's authorization and no-telemetry boundaries.
- [x] No credentials, engagement data, transcripts, reports, browser profiles, or runtime state are included.
- [x] Tests cover the release regression; the documented package payload and partial-release integrity contracts remain unchanged.
- [x] The pinned compression dependency is build-only and does not enter runtime packages.