### PR TITLE
Fit x64 npm packages under registry limits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,6 +289,13 @@ jobs:
           --input release-inputs
           --output release-assets
           --version "$RELEASE_VERSION"
+      - name: Fit x64 npm packages within the registry request limit
+        shell: bash
+        run: |
+          for platform in linux windows; do
+            bun scripts/repack-npm-platform-package.ts \
+              --file "release-assets/cyberful-org-cyberful-$platform-x64-$RELEASE_VERSION.tgz"
+          done
       - name: Pack the public launcher
         shell: bash
         run: >-
@@ -296,6 +303,13 @@ jobs:
           --meta
           --version "$RELEASE_VERSION"
           --output release-meta
+      - name: Install and execute the registry-sized Linux package
+        shell: bash
+        run: >-
+          bun cyberful/script/smoke-npm.ts
+          --platform-package "release-assets/cyberful-org-cyberful-linux-x64-$RELEASE_VERSION.tgz"
+          --meta-package "release-meta/packages/cyberful-$RELEASE_VERSION.tgz"
+          --version "$RELEASE_VERSION"
       - name: Add the launcher to the release set
         shell: bash
         run: cp release-meta/packages/*.tgz release-assets/
@@ -580,29 +594,39 @@ jobs:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
           run-id: ${{ inputs.resume_run_id }}
-      - name: Recompress the oversized npm package without changing its tar payload
-        env:
-          PACKAGE_ASSET: cyberful-org-cyberful-linux-x64-${{ inputs.version }}.tgz
+      - name: Fit x64 npm packages within the registry request limit
         shell: bash
         run: |
-          bun scripts/optimize-npm-package.ts --file "release-assets/$PACKAGE_ASSET"
+          for platform in linux windows; do
+            bun scripts/repack-npm-platform-package.ts \
+              --file "release-assets/cyberful-org-cyberful-$platform-x64-$RELEASE_VERSION.tgz"
+          done
           bun scripts/write-checksums.ts release-assets
-      - name: Reconcile only the recompressed draft assets
+      - name: Install and execute the registry-sized Linux package
+        shell: bash
+        run: >-
+          bun cyberful/script/smoke-npm.ts
+          --platform-package "release-assets/cyberful-org-cyberful-linux-x64-$RELEASE_VERSION.tgz"
+          --meta-package "release-assets/cyberful-$RELEASE_VERSION.tgz"
+          --version "$RELEASE_VERSION"
+      - name: Reconcile only the repacked draft assets
         env:
           GH_TOKEN: ${{ github.token }}
-          PACKAGE_ASSET: cyberful-org-cyberful-linux-x64-${{ inputs.version }}.tgz
           RELEASE_ID: ${{ steps.release.outputs.release_id }}
           TAG: v${{ inputs.version }}
         shell: bash
         run: |
-          # ── Recovery Mutates Only Two Named Draft Assets ─────────────
+          # ── Recovery Mutates Only Three Named Draft Assets ────────────
           # The failed run already staged a complete draft whose other files must
-          # remain byte-identical. Recovery permits replacement only for the npm
-          # tarball whose deflate stream changed and the checksum manifest that
-          # records that new digest. Matching retries preserve both assets, while
-          # any mismatch elsewhere still fails closed in the uploader below.
+          # remain byte-identical. Recovery permits replacement only for the two
+          # x64 npm tarballs whose binary storage changed and the checksum manifest
+          # that records their new digests. Matching retries preserve these assets,
+          # while any mismatch elsewhere still fails closed in the uploader below.
           # ─────────────────────────────────────────────────────────────
-          for asset_name in "$PACKAGE_ASSET" SHA256SUMS; do
+          for asset_name in \
+            "cyberful-org-cyberful-linux-x64-$RELEASE_VERSION.tgz" \
+            "cyberful-org-cyberful-windows-x64-$RELEASE_VERSION.tgz" \
+            SHA256SUMS; do
             local_digest="sha256:$(sha256sum "release-assets/$asset_name" | cut -d' ' -f1)"
             asset_record="$(
               gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \

--- a/bun.lock
+++ b/bun.lock
@@ -74,7 +74,6 @@
         "yauzl": "3.2.0",
       },
       "devDependencies": {
-        "@gfx/zopfli": "1.0.15",
         "@hey-api/openapi-ts": "0.99.0",
         "@parcel/watcher-darwin-arm64": "2.5.1",
         "@parcel/watcher-darwin-x64": "2.5.1",
@@ -329,8 +328,6 @@
     "@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
     "@gar/promise-retry": ["@gar/promise-retry@1.0.3", "", {}, "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA=="],
-
-    "@gfx/zopfli": ["@gfx/zopfli@1.0.15", "", { "dependencies": { "base64-js": "^1.3.0" } }, "sha512-7mBgpi7UD82fsff5ThQKet0uBTl4BYerQuc+/qA1ELTwWEiIedRTcD3JgiUu9wwZ2kytW8JOb165rSdAt8PfcQ=="],
 
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 

--- a/cyberful/package.json
+++ b/cyberful/package.json
@@ -37,7 +37,6 @@
     "./*": "./src/*.ts"
   },
   "devDependencies": {
-    "@gfx/zopfli": "1.0.15",
     "@hey-api/openapi-ts": "0.99.0",
     "@parcel/watcher-darwin-arm64": "2.5.1",
     "@parcel/watcher-darwin-x64": "2.5.1",

--- a/cyberful/script/package-npm.test.ts
+++ b/cyberful/script/package-npm.test.ts
@@ -8,12 +8,11 @@ import { afterEach, describe, expect, test } from "bun:test"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
-import { gunzipSync, gzipSync } from "node:zlib"
 import {
   metaManifest,
-  optimizeNpmPackage,
   packNpmPackage,
   platformManifest,
+  repackUniversalX64Package,
   stageMetaPackage,
   stagePlatformPackage,
 } from "./package-npm"
@@ -146,37 +145,65 @@ describe("npm package staging", () => {
 })
 
 describe("npm package upload size", () => {
-  test("recompresses an oversized archive without changing its tar payload", async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "cyberful-npm-compression-"))
-    temporaryRoots.push(root)
-    const file = path.join(root, "package.tgz")
-    const tar = Buffer.from("cyberful-release-payload\n".repeat(100_000))
-    const original = gzipSync(tar, { level: 1 })
-    fs.writeFileSync(file, original)
+  test("stores one baseline-compatible binary body behind both x64 filenames", async () => {
+    const repositoryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cyberful-npm-universal-"))
+    temporaryRoots.push(repositoryRoot)
+    fs.writeFileSync(path.join(repositoryRoot, "LICENSE"), "AGPL-3.0-only")
+    writePackageDocuments(repositoryRoot)
+    const optimized = Buffer.alloc(1_000_000)
+    const baseline = Buffer.alloc(1_000_000)
+    for (let index = 0, state = 0x12345678; index < optimized.length; index += 1) {
+      state ^= state << 13
+      state ^= state >>> 17
+      state ^= state << 5
+      optimized[index] = state & 0xff
+      baseline[index] = (state >>> 8) & 0xff
+    }
+    for (const [target, contents] of [
+      ["cyberful-linux-x64", optimized],
+      ["cyberful-linux-x64-baseline", baseline],
+    ] as const) {
+      const binary = path.join(repositoryRoot, "cyberful/dist", target, "bin/cyberful")
+      fs.mkdirSync(path.dirname(binary), { recursive: true })
+      fs.writeFileSync(binary, contents)
+    }
 
-    const result = await optimizeNpmPackage(file, {
-      compressionThresholdBytes: 1,
-      uploadLimitBytes: original.byteLength,
+    const packageRoot = path.join(repositoryRoot, "package")
+    stagePlatformPackage({ repositoryRoot, packageRoot, platform: "linux", architecture: "x64", version: "1.2.3" })
+    const artifact = packNpmPackage(packageRoot, path.join(repositoryRoot, "packed"))
+    const result = await repackUniversalX64Package(artifact)
+
+    expect(result.afterBytes).toBeLessThan(result.beforeBytes * 0.75)
+    const extracted = path.join(repositoryRoot, "extracted")
+    fs.mkdirSync(extracted)
+    const unpack = Bun.spawnSync(["tar", "-xzf", artifact, "-C", extracted], {
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 30_000,
+      maxBuffer: 1_048_576,
     })
-
-    expect(result.optimized).toBeTrue()
-    expect(result.bytes).toBeLessThan(original.byteLength)
-    const first = fs.readFileSync(file)
-    expect(gunzipSync(first)).toEqual(tar)
-
-    fs.writeFileSync(file, original)
-    await optimizeNpmPackage(file, { compressionThresholdBytes: 1, uploadLimitBytes: original.byteLength })
-    expect(fs.readFileSync(file)).toEqual(first)
+    expect(unpack.exitCode).toBe(0)
+    const installed = path.join(extracted, "package/bin/cyberful")
+    const installedBaseline = path.join(extracted, "package/bin/cyberful-baseline")
+    expect(fs.readFileSync(installed)).toEqual(baseline)
+    expect(fs.readFileSync(installedBaseline)).toEqual(baseline)
+    expect(fs.statSync(installed).ino).toBe(fs.statSync(installedBaseline).ino)
   })
 
-  test("rejects a package that still exceeds the upload limit", async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "cyberful-npm-limit-"))
-    temporaryRoots.push(root)
-    const file = path.join(root, "package.tgz")
-    fs.writeFileSync(file, gzipSync(Buffer.from("cyberful")))
+  test("rejects a repacked package that still exceeds the publish limit", async () => {
+    const repositoryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cyberful-npm-limit-"))
+    temporaryRoots.push(repositoryRoot)
+    fs.writeFileSync(path.join(repositoryRoot, "LICENSE"), "AGPL-3.0-only")
+    writePackageDocuments(repositoryRoot)
+    for (const target of ["cyberful-linux-x64", "cyberful-linux-x64-baseline"]) {
+      const binary = path.join(repositoryRoot, "cyberful/dist", target, "bin/cyberful")
+      fs.mkdirSync(path.dirname(binary), { recursive: true })
+      fs.writeFileSync(binary, target)
+    }
+    const packageRoot = path.join(repositoryRoot, "package")
+    stagePlatformPackage({ repositoryRoot, packageRoot, platform: "linux", architecture: "x64", version: "1.2.3" })
+    const artifact = packNpmPackage(packageRoot, path.join(repositoryRoot, "packed"))
 
-    await expect(optimizeNpmPackage(file, { compressionThresholdBytes: 1, uploadLimitBytes: 1 })).rejects.toThrow(
-      "remains above",
-    )
+    await expect(repackUniversalX64Package(artifact, { uploadLimitBytes: 1 })).rejects.toThrow("remains above")
   })
 })

--- a/cyberful/script/package-npm.ts
+++ b/cyberful/script/package-npm.ts
@@ -3,16 +3,13 @@
 // Stages platform binaries and the portable launcher into their public npm
 // layouts, writes exact-version manifests, and packs one audited artifact.
 // → cyberful/bin/resolve.cjs — resolves optional platform packages at runtime.
-// @docs/development/release.md
 // ────────────────────────────────────────────────────────────────────
 
-import crypto from "node:crypto"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
-import { gunzipSync } from "node:zlib"
-import { gzipAsync } from "@gfx/zopfli"
 import semver from "semver"
+import { extract, list } from "tar"
 
 export type NpmPlatform = "darwin" | "linux" | "windows"
 export type NpmArchitecture = "arm64" | "x64"
@@ -27,8 +24,7 @@ const publicPackages = [
   "@cyberful-org/cyberful-windows-x64",
 ]
 const publicTargets = new Set(["darwin-arm64", "darwin-x64", "linux-x64", "windows-x64"])
-const npmCompressionThresholdBytes = 250_000_000
-const npmUploadLimitBytes = 256_000_000
+const npmPublishTarballLimitBytes = 190_000_000
 const maximumUnpackedTarBytes = 1_500_000_000
 const releaseNotices = [
   ["THIRD_PARTY_NOTICES.md", "THIRD_PARTY_NOTICES.md"],
@@ -222,67 +218,131 @@ export function packNpmPackage(directory: string, destination: string) {
   }
 }
 
-// ── Large Packages Preserve Their Exact Tar Payload ────────────────
-// npm rejects compressed uploads near 256 MB even when every declared file is
-// valid. npm pack already uses gzip level 9, so oversized platform packages are
-// recompressed deterministically with one Zopfli iteration while retaining the
-// exact tar bytes. A bounded inflate plus a post-compression digest check makes
-// archive corruption or an unexpectedly large input fail before publication.
+function parsePackageManifest(packageRoot: string) {
+  const manifestFile = path.join(packageRoot, "package.json")
+  let value: unknown
+  try {
+    value = JSON.parse(fs.readFileSync(manifestFile, "utf8"))
+  } catch (error) {
+    throw new Error(`Cannot read npm package manifest ${manifestFile}`, { cause: error })
+  }
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("name" in value) ||
+    typeof value.name !== "string" ||
+    !("version" in value) ||
+    typeof value.version !== "string" ||
+    !semver.valid(value.version)
+  ) {
+    throw new Error(`npm package manifest must contain a package name and valid version: ${manifestFile}`)
+  }
+  return { name: value.name, version: value.version }
+}
+
+async function validateNpmArchive(file: string) {
+  let unpackedBytes = 0
+  let entries = 0
+  try {
+    await list({
+      file,
+      strict: true,
+      onReadEntry(entry) {
+        const normalized = entry.path.replaceAll("\\", "/").replace(/\/$/, "")
+        if (
+          (normalized !== "package" && !normalized.startsWith("package/")) ||
+          normalized.split("/").some((segment) => segment === "..") ||
+          path.posix.isAbsolute(normalized) ||
+          (entry.type !== "File" && entry.type !== "Directory")
+        ) {
+          throw new Error(`npm package contains an unsafe archive entry: ${entry.path}`)
+        }
+        unpackedBytes += entry.size
+        entries += 1
+        if (unpackedBytes > maximumUnpackedTarBytes) {
+          throw new Error(`npm package expands beyond ${maximumUnpackedTarBytes} bytes: ${file}`)
+        }
+      },
+    })
+  } catch (error) {
+    throw new Error(`Cannot validate npm package ${file}`, { cause: error })
+  }
+  if (entries === 0) throw new Error(`npm package is empty: ${file}`)
+}
+
+// ── Universal x64 Packages Store One Binary Body ───────────────────
+// npm publishes a tarball inside a larger registry request, so two independent
+// standalone executables can exceed the request limit even when the compressed
+// archive itself appears smaller than that limit. Linux and Windows npm packages
+// therefore retain both launcher-visible filenames as hard links to the baseline
+// executable, which runs on AVX2 and older x64 hosts while storing one byte body.
+// Standalone release archives are assembled before this transformation and keep
+// their distinct optimized and baseline binaries.
 // ────────────────────────────────────────────────────────────────────
-export async function optimizeNpmPackage(
-  file: string,
-  options: { compressionThresholdBytes?: number; uploadLimitBytes?: number } = {},
-) {
+export async function repackUniversalX64Package(file: string, options: { uploadLimitBytes?: number } = {}) {
   const packageFile = path.resolve(file)
   const source = fs.statSync(packageFile, { throwIfNoEntry: false })
   if (!source?.isFile() || !packageFile.endsWith(".tgz")) throw new Error("An npm .tgz package is required")
-  const compressionThresholdBytes = options.compressionThresholdBytes ?? npmCompressionThresholdBytes
-  const uploadLimitBytes = options.uploadLimitBytes ?? npmUploadLimitBytes
-  if (!Number.isSafeInteger(compressionThresholdBytes) || compressionThresholdBytes <= 0) {
-    throw new Error("The npm compression threshold must be a positive integer")
-  }
+  const uploadLimitBytes = options.uploadLimitBytes ?? npmPublishTarballLimitBytes
   if (!Number.isSafeInteger(uploadLimitBytes) || uploadLimitBytes <= 0) {
     throw new Error("The npm upload limit must be a positive integer")
   }
-  if (source.size < compressionThresholdBytes) {
-    return { bytes: source.size, optimized: false }
-  }
+  await validateNpmArchive(packageFile)
 
-  const original = Buffer.from(await Bun.file(packageFile).arrayBuffer())
-  let tar: Buffer
+  const stagingRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cyberful-npm-universal-"))
+  const replacementRoot = fs.mkdtempSync(path.join(path.dirname(packageFile), ".cyberful-npm-repack-"))
   try {
-    tar = gunzipSync(original, { maxOutputLength: maximumUnpackedTarBytes })
-  } catch (error) {
-    throw new Error(`Cannot inflate npm package ${packageFile}`, { cause: error })
-  }
-  const tarDigest = crypto.createHash("sha256").update(tar).digest("hex")
-  const optimized = Buffer.from(await gzipAsync(tar, { numiterations: 1 }))
-  let restored: Buffer
-  try {
-    restored = gunzipSync(optimized, { maxOutputLength: maximumUnpackedTarBytes })
-  } catch (error) {
-    throw new Error(`Cannot verify optimized npm package ${packageFile}`, { cause: error })
-  }
-  if (
-    restored.byteLength !== tar.byteLength ||
-    crypto.createHash("sha256").update(restored).digest("hex") !== tarDigest
-  ) {
-    throw new Error(`Optimized npm package changed the tar payload: ${packageFile}`)
-  }
-  const selected = optimized.byteLength < original.byteLength ? optimized : original
-  if (selected.byteLength >= uploadLimitBytes) {
-    throw new Error(`npm package remains above the ${uploadLimitBytes}-byte upload limit: ${packageFile}`)
-  }
-  if (selected === original) return { bytes: original.byteLength, optimized: false }
+    await extract({ file: packageFile, cwd: stagingRoot, strict: true, preservePaths: false, unlink: true })
+    const packageRoot = path.join(stagingRoot, "package")
+    const manifest = parsePackageManifest(packageRoot)
+    const extension = manifest.name === "@cyberful-org/cyberful-windows-x64" ? ".exe" : ""
+    if (
+      manifest.name !== "@cyberful-org/cyberful-linux-x64" &&
+      manifest.name !== "@cyberful-org/cyberful-windows-x64"
+    ) {
+      throw new Error(`Only Linux and Windows x64 npm packages can be repacked: ${manifest.name}`)
+    }
 
-  const temporary = `${packageFile}.${crypto.randomUUID()}.tmp`
-  try {
-    await Bun.write(temporary, selected)
-    fs.renameSync(temporary, packageFile)
+    const optimizedBinary = path.join(packageRoot, "bin", `cyberful${extension}`)
+    const baselineBinary = path.join(packageRoot, "bin", `cyberful-baseline${extension}`)
+    for (const binary of [optimizedBinary, baselineBinary]) {
+      if (!fs.statSync(binary, { throwIfNoEntry: false })?.isFile()) {
+        throw new Error(`Required x64 npm binary is missing: ${binary}`)
+      }
+    }
+    fs.rmSync(optimizedBinary)
+    fs.linkSync(baselineBinary, optimizedBinary)
+
+    const repacked = packNpmPackage(packageRoot, replacementRoot)
+    if (path.basename(repacked) !== path.basename(packageFile)) {
+      throw new Error(`Repacked npm filename changed from ${path.basename(packageFile)} to ${path.basename(repacked)}`)
+    }
+    const bytes = fs.statSync(repacked).size
+    if (bytes >= uploadLimitBytes) {
+      throw new Error(`npm package remains above the ${uploadLimitBytes}-byte publish limit: ${packageFile}`)
+    }
+
+    const verificationRoot = path.join(stagingRoot, "verification")
+    fs.mkdirSync(verificationRoot)
+    await extract({ file: repacked, cwd: verificationRoot, strict: true, preservePaths: false, unlink: true })
+    const verifiedBin = path.join(verificationRoot, "package", "bin")
+    const verifiedOptimized = path.join(verifiedBin, `cyberful${extension}`)
+    const verifiedBaseline = path.join(verifiedBin, `cyberful-baseline${extension}`)
+    const optimizedStat = fs.statSync(verifiedOptimized)
+    const baselineStat = fs.statSync(verifiedBaseline)
+    if (
+      optimizedStat.ino !== baselineStat.ino ||
+      !fs.readFileSync(verifiedOptimized).equals(fs.readFileSync(verifiedBaseline))
+    ) {
+      throw new Error(`Repacked npm package did not preserve one universal hard-linked binary: ${packageFile}`)
+    }
+
+    fs.renameSync(repacked, packageFile)
+    return { afterBytes: bytes, beforeBytes: source.size, packageName: manifest.name, version: manifest.version }
   } finally {
-    fs.rmSync(temporary, { force: true })
+    fs.rmSync(stagingRoot, { recursive: true, force: true })
+    fs.rmSync(replacementRoot, { recursive: true, force: true })
   }
-  return { bytes: selected.byteLength, optimized: true }
 }
 
 if (import.meta.main) {
@@ -315,6 +375,5 @@ if (import.meta.main) {
     })
   }
   const artifact = packNpmPackage(staged, path.join(output, "packages"))
-  const compression = await optimizeNpmPackage(artifact)
-  console.log(JSON.stringify({ artifact, compression, staged }, null, 2))
+  console.log(JSON.stringify({ artifact, staged }, null, 2))
 }

--- a/scripts/repack-npm-platform-package.ts
+++ b/scripts/repack-npm-platform-package.ts
@@ -1,13 +1,12 @@
 #!/usr/bin/env bun
-// ── npm Release Artifact Optimization ───────────────────────────────
-// Applies the package assembler's bounded, byte-preserving compression policy
-// to one existing npm tarball so a staged partial release can resume safely.
-// → cyberful/script/package-npm.ts — owns the compression and integrity checks.
-// @docs/development/release.md
+// ── npm x64 Release Artifact Repacking ─────────────────────────────
+// Rewrites one staged Linux or Windows x64 npm tarball around a single
+// baseline-compatible binary body while preserving both public filenames.
+// → cyberful/script/package-npm.ts — owns archive validation and repacking.
 // ────────────────────────────────────────────────────────────────────
 
 import path from "node:path"
-import { optimizeNpmPackage } from "../cyberful/script/package-npm"
+import { repackUniversalX64Package } from "../cyberful/script/package-npm"
 
 function argument(name: string) {
   const indexes = Bun.argv.flatMap((value, index) => (value === name ? [index] : []))
@@ -21,5 +20,5 @@ function argument(name: string) {
 const file = argument("--file")
 if (!file) throw new Error("--file is required")
 const packageFile = path.resolve(file)
-const result = await optimizeNpmPackage(packageFile)
+const result = await repackUniversalX64Package(packageFile)
 console.log(JSON.stringify({ file: packageFile, ...result }, null, 2))


### PR DESCRIPTION
## Summary
- Replace the insufficient compression-only recovery with validated hard-link repacking for the Linux and Windows x64 npm tarballs.
- Keep both launcher-visible binary names while storing the baseline-compatible executable once; standalone GitHub archives retain their distinct optimized and baseline binaries.
- Enforce a 190 MB pre-publish ceiling, smoke the repacked Linux install, and limit draft reconciliation to the two npm assets plus SHA256SUMS.

## Verification
- `make typecheck`
- `make test-bun` (1,046 application tests and 4 browser package tests)
- 17 targeted release/package tests
- Prettier check
- YAML parse and Bash syntax validation for all 41 workflow run blocks
- `git diff --check`

## Security and release impact
- [x] The change stays within Cyberful's authorization and no-telemetry boundaries.
- [x] No credentials, engagement data, transcripts, reports, browser profiles, or runtime state are included.
- [x] Tests cover behavior changes; the retired website documentation pipeline is not reintroduced.
- [x] No new redistributed dependency is added; the ineffective Zopfli dependency is removed.