### PR TITLE
Publish regular universal x64 npm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -601,6 +601,11 @@ jobs:
             bun scripts/repack-npm-platform-package.ts \
               --file "release-assets/cyberful-org-cyberful-$platform-x64-$RELEASE_VERSION.tgz"
           done
+          bun cyberful/script/package-npm.ts \
+            --meta \
+            --version "$RELEASE_VERSION" \
+            --output release-recovery-meta
+          cp "release-recovery-meta/packages/cyberful-$RELEASE_VERSION.tgz" release-assets/
           bun scripts/write-checksums.ts release-assets
       - name: Install and execute the registry-sized Linux package
         shell: bash
@@ -616,14 +621,15 @@ jobs:
           TAG: v${{ inputs.version }}
         shell: bash
         run: |
-          # ── Recovery Mutates Only Three Named Draft Assets ────────────
+          # ── Recovery Mutates Only Four Named Draft Assets ─────────────
           # The failed run already staged a complete draft whose other files must
-          # remain byte-identical. Recovery permits replacement only for the two
-          # x64 npm tarballs whose binary storage changed and the checksum manifest
-          # that records their new digests. Matching retries preserve these assets,
-          # while any mismatch elsewhere still fails closed in the uploader below.
+          # remain byte-identical. Recovery permits replacement only for the two x64
+          # npm tarballs whose binary layout changed, their matching launcher, and
+          # the checksum manifest that records their new digests. Matching retries
+          # preserve these assets; any mismatch elsewhere still fails closed below.
           # ─────────────────────────────────────────────────────────────
           for asset_name in \
+            "cyberful-$RELEASE_VERSION.tgz" \
             "cyberful-org-cyberful-linux-x64-$RELEASE_VERSION.tgz" \
             "cyberful-org-cyberful-windows-x64-$RELEASE_VERSION.tgz" \
             SHA256SUMS; do

--- a/cyberful/bin/resolve.cjs
+++ b/cyberful/bin/resolve.cjs
@@ -94,9 +94,10 @@ function target(
   if (!platform || !architecture) return
   if (platform === "linux" && musl) return
   if (architecture === "arm64" && platform !== "darwin") return
+  const baseline = architecture === "x64" && !avx2
   return {
     packageName: `@cyberful-org/cyberful-${platform}-${architecture}`,
-    binaryName: `cyberful${architecture === "x64" && !avx2 ? "-baseline" : ""}${platform === "windows" ? ".exe" : ""}`,
+    binaryName: `cyberful${platform === "darwin" && baseline ? "-baseline" : ""}${platform === "windows" ? ".exe" : ""}`,
   }
 }
 

--- a/cyberful/script/npm-launcher.test.ts
+++ b/cyberful/script/npm-launcher.test.ts
@@ -66,10 +66,11 @@ describe("npm launcher", () => {
     })
   })
 
-  test("selects the baseline x64 binary when AVX2 is unavailable", () => {
+  test("uses the universal package binary outside macOS", () => {
     expect(resolver.target("linux", "x64", false, true)?.binaryName).toBe("cyberful")
-    expect(resolver.target("linux", "x64", false, false)?.binaryName).toBe("cyberful-baseline")
-    expect(resolver.target("windows", "x64", false, false)?.binaryName).toBe("cyberful-baseline.exe")
+    expect(resolver.target("linux", "x64", false, false)?.binaryName).toBe("cyberful")
+    expect(resolver.target("windows", "x64", false, false)?.binaryName).toBe("cyberful.exe")
+    expect(resolver.target("darwin", "x64", false, false)?.binaryName).toBe("cyberful-baseline")
   })
 
   test("finds scoped platform packages above the launcher", () => {

--- a/cyberful/script/package-npm.test.ts
+++ b/cyberful/script/package-npm.test.ts
@@ -145,7 +145,7 @@ describe("npm package staging", () => {
 })
 
 describe("npm package upload size", () => {
-  test("stores one baseline-compatible binary body behind both x64 filenames", async () => {
+  test("stores one regular baseline-compatible binary in registry-sized x64 packages", async () => {
     const repositoryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cyberful-npm-universal-"))
     temporaryRoots.push(repositoryRoot)
     fs.writeFileSync(path.join(repositoryRoot, "LICENSE"), "AGPL-3.0-only")
@@ -186,8 +186,7 @@ describe("npm package upload size", () => {
     const installed = path.join(extracted, "package/bin/cyberful")
     const installedBaseline = path.join(extracted, "package/bin/cyberful-baseline")
     expect(fs.readFileSync(installed)).toEqual(baseline)
-    expect(fs.readFileSync(installedBaseline)).toEqual(baseline)
-    expect(fs.statSync(installed).ino).toBe(fs.statSync(installedBaseline).ino)
+    expect(fs.existsSync(installedBaseline)).toBeFalse()
   })
 
   test("rejects a repacked package that still exceeds the publish limit", async () => {

--- a/cyberful/script/package-npm.ts
+++ b/cyberful/script/package-npm.ts
@@ -270,14 +270,14 @@ async function validateNpmArchive(file: string) {
   if (entries === 0) throw new Error(`npm package is empty: ${file}`)
 }
 
-// ── Universal x64 Packages Store One Binary Body ───────────────────
+// ── Universal x64 Packages Store One Baseline Binary ───────────────
 // npm publishes a tarball inside a larger registry request, so two independent
 // standalone executables can exceed the request limit even when the compressed
-// archive itself appears smaller than that limit. Linux and Windows npm packages
-// therefore retain both launcher-visible filenames as hard links to the baseline
-// executable, which runs on AVX2 and older x64 hosts while storing one byte body.
-// Standalone release archives are assembled before this transformation and keep
-// their distinct optimized and baseline binaries.
+// archive itself appears smaller than that limit. npm also rejects hard links in
+// published packages. Linux and Windows npm packages therefore expose only the
+// baseline executable under the canonical cyberful filename; it runs on AVX2 and
+// older x64 hosts. Their matching launcher knows this layout. Standalone release
+// archives are assembled first and keep distinct optimized and baseline binaries.
 // ────────────────────────────────────────────────────────────────────
 export async function repackUniversalX64Package(file: string, options: { uploadLimitBytes?: number } = {}) {
   const packageFile = path.resolve(file)
@@ -311,7 +311,7 @@ export async function repackUniversalX64Package(file: string, options: { uploadL
       }
     }
     fs.rmSync(optimizedBinary)
-    fs.linkSync(baselineBinary, optimizedBinary)
+    fs.renameSync(baselineBinary, optimizedBinary)
 
     const repacked = packNpmPackage(packageRoot, replacementRoot)
     if (path.basename(repacked) !== path.basename(packageFile)) {
@@ -328,13 +328,8 @@ export async function repackUniversalX64Package(file: string, options: { uploadL
     const verifiedBin = path.join(verificationRoot, "package", "bin")
     const verifiedOptimized = path.join(verifiedBin, `cyberful${extension}`)
     const verifiedBaseline = path.join(verifiedBin, `cyberful-baseline${extension}`)
-    const optimizedStat = fs.statSync(verifiedOptimized)
-    const baselineStat = fs.statSync(verifiedBaseline)
-    if (
-      optimizedStat.ino !== baselineStat.ino ||
-      !fs.readFileSync(verifiedOptimized).equals(fs.readFileSync(verifiedBaseline))
-    ) {
-      throw new Error(`Repacked npm package did not preserve one universal hard-linked binary: ${packageFile}`)
+    if (!fs.statSync(verifiedOptimized).isFile() || fs.existsSync(verifiedBaseline)) {
+      throw new Error(`Repacked npm package did not preserve one universal baseline binary: ${packageFile}`)
     }
 
     fs.renameSync(repacked, packageFile)

--- a/scripts/repack-npm-platform-package.ts
+++ b/scripts/repack-npm-platform-package.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 // ── npm x64 Release Artifact Repacking ─────────────────────────────
-// Rewrites one staged Linux or Windows x64 npm tarball around a single
-// baseline-compatible binary body while preserving both public filenames.
+// Rewrites one staged Linux or Windows x64 npm tarball around one regular
+// baseline-compatible binary exposed under the canonical public filename.
 // → cyberful/script/package-npm.ts — owns archive validation and repacking.
 // ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- publish Linux and Windows x64 npm packages with one regular baseline-compatible executable under the canonical filename
- preserve the separate optimized and baseline binaries in standalone GitHub archives
- rebuild the launcher during release recovery so its resolver matches the recovered platform package layout
- restrict recovery mutation to the launcher, two x64 npm tarballs, and SHA256SUMS

This replaces the hard-link layout rejected by npm with E415 while keeping the registry upload below its request-size limit.

## Verification

- `make typecheck`
- `make test-bun` (1,046 application tests and 4 browser package tests)
- targeted release and packaging tests (21 passed)
- full Python skill tests; one process-group cleanup test hit an ambient macOS EPERM once and passed immediately in isolated rerun
- `git diff --check`
- Prettier check for all changed files
- YAML parse and `bash -n` for all 41 workflow Bash blocks

## Security and release impact

- [x] The change stays within Cyberful's authorization and no-telemetry boundaries.
- [x] No credentials, engagement data, transcripts, reports, browser profiles, or runtime state are included.
- [x] Tests cover behavior changes and documentation is updated where required.
- [x] New or redistributed dependencies and assets have compatible provenance and notices.